### PR TITLE
test: port tests to bun:test with grammY mock helpers #6

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,5 +18,14 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Typecheck
+        run: bun run typecheck
+
       - name: Lint
         run: bun run lint
+
+      - name: Format check
+        run: bun run format:check
+
+      - name: Test
+        run: bun run test

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -11,10 +11,16 @@ const GROUPS = ['group', 'supergroup', 'channel'];
 export function createBot(token: string): Bot {
   const bot = new Bot(token);
 
+  bot.catch((err) => {
+    console.error(`Error handling update ${err.ctx.update.update_id}:`, err.error);
+  });
+
   bot.command(['start', 'help'], async (ctx) => {
+    const isGroup = GROUPS.includes(ctx.chat.type);
     await ctx.reply(helpReply(), {
       parse_mode: 'Markdown',
       link_preview_options: { is_disabled: true },
+      ...(isGroup ? { reply_parameters: { message_id: ctx.msgId } } : {}),
     });
   });
 
@@ -51,9 +57,11 @@ export function createBot(token: string): Bot {
   });
 
   bot.command(['sroll', 'droll'], async (ctx) => {
+    const isGroup = GROUPS.includes(ctx.chat.type);
     await ctx.reply(deprecatedReply(), {
       parse_mode: 'Markdown',
       link_preview_options: { is_disabled: true },
+      ...(isGroup ? { reply_parameters: { message_id: ctx.msgId } } : {}),
     });
   });
 

--- a/src/handlers/inline.ts
+++ b/src/handlers/inline.ts
@@ -13,7 +13,7 @@ function createInputMessageContent(text: string) {
   return {
     message_text: text,
     parse_mode: 'Markdown' as const,
-    disable_web_page_preview: true,
+    link_preview_options: { is_disabled: true },
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,13 @@ if (!token) {
 }
 
 const bot = createBot(token);
+const webhookPath = `/bot${token}`;
 
 if (webhookUrl) {
-  await bot.api.setWebhook(webhookUrl);
-  console.log(`Webhook set to: ${webhookUrl}`);
+  await bot.api.setWebhook(`${webhookUrl}${webhookPath}`);
+  console.log(`Webhook set to: ${webhookUrl}${webhookPath}`);
+} else {
+  console.warn('WEBHOOK_URL is not set — bot will not receive Telegram updates');
 }
 
 const handleUpdate = webhookCallback(bot, 'bun');
@@ -22,7 +25,7 @@ Bun.serve({
   port,
   async fetch(req) {
     const url = new URL(req.url);
-    if (req.method === 'POST') {
+    if (req.method === 'POST' && url.pathname === webhookPath) {
       return handleUpdate(req);
     }
     if (url.pathname === '/health') {

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { TestBot } from './helpers';
+
+let bot: TestBot;
+
+beforeEach(() => {
+  bot = new TestBot();
+});
+
+describe('Bot message options', () => {
+  test('should reply with Markdown parse mode', async () => {
+    await bot.send('/roll d20');
+    const opts = bot.getLastReplyOptions();
+    expect(opts.parse_mode).toEqual('Markdown');
+  });
+
+  test('should include reply_parameters in group chats', async () => {
+    await bot.send('/roll d20', 'group');
+    const opts = bot.getLastReplyOptions();
+    expect(opts.reply_parameters).toBeDefined();
+    expect(opts.reply_parameters.message_id).toBeDefined();
+  });
+
+  test('should include reply_parameters in supergroup chats', async () => {
+    await bot.send('/roll d20', 'supergroup');
+    const opts = bot.getLastReplyOptions();
+    expect(opts.reply_parameters).toBeDefined();
+  });
+
+  test('should include reply_parameters in channel chats', async () => {
+    await bot.send('/roll d20', 'channel');
+    const opts = bot.getLastReplyOptions();
+    expect(opts.reply_parameters).toBeDefined();
+  });
+
+  test('should not include reply_parameters in private chats', async () => {
+    await bot.send('/roll d20', 'private');
+    const opts = bot.getLastReplyOptions();
+    expect(opts.reply_parameters).toBeUndefined();
+  });
+
+  test('should route @botname-suffixed commands', async () => {
+    const pattern = /`\([\d+-dDf!>]+\)` \*\d+\*/;
+    expect(await bot.send('/roll@testbot d20')).toMatch(pattern);
+    expect(await bot.send('/full@testbot d20')).toMatch(/`\([\d+-dDf!>]+\)` \*\d+\* `\[/);
+    expect(await bot.send('/random@testbot')).toMatch(/`\(d100\)` \*\d{1,3}\*/);
+  });
+});

--- a/test/handlers/deprecated.test.ts
+++ b/test/handlers/deprecated.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { TestBot } from '../helpers';
+import { deprecatedText } from '../../src/text';
+
+let bot: TestBot;
+
+beforeEach(() => {
+  bot = new TestBot();
+});
+
+describe('Deprecated commands', () => {
+  test('should reply with notice for /sroll', async () => {
+    expect(await bot.send('/sroll')).toEqual(deprecatedText);
+  });
+
+  test('should reply with notice for /droll', async () => {
+    expect(await bot.send('/droll')).toEqual(deprecatedText);
+  });
+});

--- a/test/handlers/full.test.ts
+++ b/test/handlers/full.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { TestBot } from '../helpers';
+import { errorText } from '../../src/text';
+
+let bot: TestBot;
+
+beforeEach(() => {
+  bot = new TestBot();
+});
+
+describe('/full', () => {
+  test('should notify of invalid input', async () => {
+    expect(await bot.send('/full')).toEqual(errorText);
+    expect(await bot.send('/full a')).toEqual(errorText);
+    expect(await bot.send('/full -7')).toEqual(errorText);
+    expect(await bot.send('/full 6d')).toEqual(errorText);
+  });
+
+  test('should parse and roll notation with individual rolls', async () => {
+    const pattern = /`\([\d+-dDf!>]+\)` \*\d+\* `\[\d+(?:,\d+)*\]`/;
+    expect(await bot.send('/full 10')).toMatch(pattern);
+    expect(await bot.send('/full d20')).toMatch(pattern);
+    expect(await bot.send('/full d8!')).toMatch(pattern);
+    expect(await bot.send('/full 4d20-1')).toMatch(pattern);
+    expect(await bot.send('/full 3d10!>6f3')).toMatch(pattern);
+  });
+
+  test('should work in group chats with reply', async () => {
+    const pattern = /`\([\d+-dDf!>]+\)` \*\d+\* `\[\d+(?:,\d+)*\]`/;
+    expect(await bot.send('/full 10', 'group')).toMatch(pattern);
+
+    const opts = bot.getLastReplyOptions();
+    expect(opts.reply_parameters).toBeDefined();
+  });
+
+  test('should limit roll values', async () => {
+    const classicPattern = /`\(12d999999999(\+|-)999999999\)` \*\d+\*/;
+    const wodPattern = /`\(12d999999999!>999999999f999999998\)` \*\d+\*/;
+
+    expect(await bot.send('/full 100d1234567890+1234567890')).toMatch(classicPattern);
+    expect(await bot.send('/full 77d7777777777-7777777777')).toMatch(classicPattern);
+    expect(await bot.send('/full 999d1234567890!>7777777777f1111111111')).toMatch(wodPattern);
+  });
+});

--- a/test/handlers/help.test.ts
+++ b/test/handlers/help.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { TestBot } from '../helpers';
+import { helpText } from '../../src/text';
+
+let bot: TestBot;
+
+beforeEach(() => {
+  bot = new TestBot();
+});
+
+describe('Help commands', () => {
+  test('should reply with help text for /start', async () => {
+    expect(await bot.send('/start')).toEqual(helpText);
+  });
+
+  test('should reply with help text for /help', async () => {
+    expect(await bot.send('/help')).toEqual(helpText);
+  });
+});

--- a/test/handlers/inline.test.ts
+++ b/test/handlers/inline.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { TestBot } from '../helpers';
+
+let bot: TestBot;
+
+beforeEach(() => {
+  bot = new TestBot();
+});
+
+function expectArticles(results: any[], expected: { title: string; description?: string }[]) {
+  expect(results.length).toEqual(expected.length);
+  for (let i = 0; i < expected.length; i++) {
+    expect(results[i]).toMatchObject(expected[i]);
+  }
+}
+
+describe('Inline queries', () => {
+  test('should return default articles for empty query', async () => {
+    const results = await bot.sendInline('');
+    expectArticles(results, [
+      { title: 'Classic', description: 'd20' },
+      { title: 'World of Darkness', description: 'd10>6' },
+      { title: 'Random', description: 'd100' },
+    ]);
+  });
+
+  test('should return default articles for whitespace-only query', async () => {
+    const results = await bot.sendInline('    ');
+    expectArticles(results, [
+      { title: 'Classic', description: 'd20' },
+      { title: 'World of Darkness', description: 'd10>6' },
+      { title: 'Random', description: 'd100' },
+    ]);
+  });
+
+  test('should return only random article for invalid query', async () => {
+    const results = await bot.sendInline('abc');
+    expectArticles(results, [{ title: 'Random', description: 'd100' }]);
+  });
+
+  test('should return Classic and Random for number-only notation', async () => {
+    const results = await bot.sendInline('10');
+    expectArticles(results, [
+      { title: 'Classic', description: 'd10' },
+      { title: 'Random', description: 'd100' },
+    ]);
+  });
+
+  test('should return matching articles for valid notation', async () => {
+    const results = await bot.sendInline('d20');
+    expectArticles(results, [
+      { title: 'Classic', description: 'd20' },
+      { title: 'World of Darkness', description: 'd20>6' },
+      { title: 'Random', description: 'd100' },
+    ]);
+  });
+
+  test('should handle padded notation with whitespace', async () => {
+    const results = await bot.sendInline('  11d11 ');
+    expectArticles(results, [
+      { title: 'Classic', description: '11d11' },
+      { title: 'World of Darkness', description: '11d11>6' },
+      { title: 'Random', description: 'd100' },
+    ]);
+  });
+
+  test('should return WoD and Random for WoD-only notation', async () => {
+    const results = await bot.sendInline('4d10>5');
+    expectArticles(results, [
+      { title: 'World of Darkness', description: '4d10>5' },
+      { title: 'Random', description: 'd100' },
+    ]);
+  });
+
+  test('should limit inline query roll values', async () => {
+    const results = await bot.sendInline('d9999999999');
+    expectArticles(results, [
+      { title: 'Classic', description: 'd999999999' },
+      { title: 'World of Darkness', description: 'd999999999>6' },
+      { title: 'Random', description: 'd100' },
+    ]);
+  });
+});

--- a/test/handlers/random.test.ts
+++ b/test/handlers/random.test.ts
@@ -1,0 +1,20 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { TestBot } from '../helpers';
+
+let bot: TestBot;
+
+beforeEach(() => {
+  bot = new TestBot();
+});
+
+describe('/random', () => {
+  test('should reply with d100 roll', async () => {
+    const pattern = /`\(d100\)` \*\d{1,3}\*/;
+    expect(await bot.send('/random')).toMatch(pattern);
+  });
+
+  test('should ignore extra arguments', async () => {
+    const pattern = /`\(d100\)` \*\d{1,3}\*/;
+    expect(await bot.send('/random d100+1000')).toMatch(pattern);
+  });
+});

--- a/test/handlers/roll.test.ts
+++ b/test/handlers/roll.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { TestBot } from '../helpers';
+import { errorText } from '../../src/text';
+
+let bot: TestBot;
+
+beforeEach(() => {
+  bot = new TestBot();
+});
+
+describe('/roll', () => {
+  test('should notify of invalid input', async () => {
+    expect(await bot.send('/roll')).toEqual(errorText);
+    expect(await bot.send('/roll a')).toEqual(errorText);
+    expect(await bot.send('/roll -7')).toEqual(errorText);
+    expect(await bot.send('/roll 6d')).toEqual(errorText);
+  });
+
+  test('should parse and roll notation', async () => {
+    const pattern = /`\([\d+-dDf!>]+\)` \*\d+\*/;
+    expect(await bot.send('/roll 10')).toMatch(pattern);
+    expect(await bot.send('/roll d20')).toMatch(pattern);
+    expect(await bot.send('/roll d8!')).toMatch(pattern);
+    expect(await bot.send('/roll 4d20-1')).toMatch(pattern);
+    expect(await bot.send('/roll 3d10!>6f3')).toMatch(pattern);
+  });
+
+  test('should limit roll values', async () => {
+    const classicPattern = /`\(12d999999999(\+|-)999999999\)` \*\d+\*/;
+    const wodPattern = /`\(12d999999999!>999999999f999999998\)` \*\d+\*/;
+
+    expect(await bot.send('/roll 100d1234567890+1234567890')).toMatch(classicPattern);
+    expect(await bot.send('/roll 77d7777777777-7777777777')).toMatch(classicPattern);
+    expect(await bot.send('/roll 999d1234567890!>7777777777f1111111111')).toMatch(wodPattern);
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,105 @@
+import type { Bot } from 'grammy';
+import { createBot } from '../src/bot';
+
+// ? Fake token that passes grammY validation (numeric:alphanumeric)
+const FAKE_TOKEN = '0123456789:ABCdefGHIjklMNOpqrSTUvwxYZ';
+
+let updateId = 0;
+
+function nextUpdateId(): number {
+  updateId += 1;
+  return updateId;
+}
+
+function extractCommandEntity(text: string) {
+  const match = text.match(/^\/\w+(@\w+)?/);
+  if (!match) return [];
+  return [{ type: 'bot_command', offset: 0, length: match[0].length }];
+}
+
+function createMessageUpdate(text: string, chatType = 'private') {
+  return {
+    update_id: nextUpdateId(),
+    message: {
+      message_id: nextUpdateId(),
+      date: Math.floor(Date.now() / 1000),
+      text,
+      entities: extractCommandEntity(text),
+      from: { id: 1, is_bot: false, first_name: 'Test', username: 'testuser' },
+      chat: { id: 1, type: chatType, first_name: 'Test' },
+    },
+  };
+}
+
+function createInlineQueryUpdate(query: string) {
+  return {
+    update_id: nextUpdateId(),
+    inline_query: {
+      id: String(nextUpdateId()),
+      query,
+      offset: '',
+      from: { id: 1, is_bot: false, first_name: 'Test', username: 'testuser' },
+    },
+  };
+}
+
+export class TestBot {
+  bot: Bot;
+  replies: any[] = [];
+  inlineResults: any[] = [];
+
+  constructor() {
+    this.bot = createBot(FAKE_TOKEN);
+
+    // Provide fake bot info so handleUpdate works without calling bot.init()
+    this.bot.botInfo = {
+      id: 123456789,
+      is_bot: true,
+      first_name: 'TestBot',
+      username: 'testbot',
+      can_join_groups: true,
+      can_read_all_group_messages: false,
+      supports_inline_queries: true,
+      can_connect_to_business: false,
+      has_main_web_app: false,
+      has_topics_enabled: false,
+      allows_users_to_create_topics: false,
+    };
+
+    // Intercept outgoing API calls
+    this.bot.api.config.use((prev, method, payload) => {
+      if (method === 'sendMessage') {
+        this.replies.push(payload);
+        return { ok: true, result: { message_id: nextUpdateId() } } as any;
+      }
+      if (method === 'answerInlineQuery') {
+        this.inlineResults.push(payload);
+        return { ok: true, result: true } as any;
+      }
+      return { ok: true, result: {} } as any;
+    });
+  }
+
+  clear() {
+    this.replies = [];
+    this.inlineResults = [];
+  }
+
+  async send(text: string, chatType = 'private'): Promise<string> {
+    this.clear();
+    const update = createMessageUpdate(text, chatType);
+    await this.bot.handleUpdate(update as any);
+    return this.replies[0]?.text || '';
+  }
+
+  async sendInline(query: string): Promise<any[]> {
+    this.clear();
+    const update = createInlineQueryUpdate(query);
+    await this.bot.handleUpdate(update as any);
+    return this.inlineResults[0]?.results || [];
+  }
+
+  getLastReplyOptions(): any {
+    return this.replies[this.replies.length - 1] || {};
+  }
+}


### PR DESCRIPTION
Added `TestBot` helper that intercepts grammY API calls via transformer for test isolation.
Implemented 27 tests across 7 files covering all handlers, inline queries, group chat behavior, and limiter edge cases.
Fixed webhook endpoint to require secret token path, preventing unauthorized update injection.
Added `reply_parameters` to help and deprecated handlers to restore group chat reply-to parity with old code.
Added `bot.catch()` error handler and normalized `disable_web_page_preview` to `link_preview_options` in inline handler.
Updated CI workflow to run typecheck, format check, and tests in addition to lint.

Closes #6

<sub>*Drafted with AI assistance*</sub>
