### PR TITLE
feat: DM user when bot lacks chat permissions #12

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,18 +1,39 @@
-import { Bot } from 'grammy';
+import { Bot, GrammyError, HttpError } from 'grammy';
 import { rollReply } from './handlers/roll';
 import { fullReply } from './handlers/full';
 import { randomReply } from './handlers/random';
 import { helpReply } from './handlers/help';
 import { deprecatedReply } from './handlers/deprecated';
 import { createInlineArticles } from './handlers/inline';
+import { noPermissionText } from './text';
 
 const GROUPS = ['group', 'supergroup', 'channel'];
 
 export function createBot(token: string): Bot {
   const bot = new Bot(token);
 
-  bot.catch((err) => {
-    console.error(`Error handling update ${err.ctx.update.update_id}:`, err.error);
+  bot.catch(async (err) => {
+    const e = err.error;
+    if (e instanceof GrammyError) {
+      console.error(`[${e.method}] ${e.error_code}: ${e.description}`);
+      if (e.description.includes('not enough rights to send text messages')) {
+        const userId = err.ctx.from?.id;
+        if (userId) {
+          try {
+            const chatName = err.ctx.chat?.title;
+            await err.ctx.api.sendMessage(userId, noPermissionText(chatName), {
+              parse_mode: 'Markdown',
+            });
+          } catch {
+            // User hasn't started the bot — nothing we can do
+          }
+        }
+      }
+    } else if (e instanceof HttpError) {
+      console.error(`Network error: ${e.message}`);
+    } else {
+      console.error(`Error handling update ${err.ctx.update.update_id}:`, e);
+    }
   });
 
   bot.command(['start', 'help'], async (ctx) => {

--- a/src/text.ts
+++ b/src/text.ts
@@ -43,6 +43,11 @@ export const deprecatedText =
 
 export const errorText = "_Sorry, can't parse notation._";
 
+export function noPermissionText(chatName?: string): string {
+  const where = chatName ? `in *${chatName}*` : 'in this chat';
+  return `_I can't send messages ${where} — an admin needs to grant me the Send Messages permission._`;
+}
+
 export function createResultMessage(result: any): string | null {
   if (result) {
     return `\`(${result.notation})\` *${result.value}*`;


### PR DESCRIPTION
## Changes

- Added `noPermissionText()` to `src/text.ts` — builds a DM message that includes the chat name
- Updated `bot.catch` in `src/bot.ts` to detect "not enough rights" errors and DM the invoking user

Closes #12

<sub>*Drafted with AI assistance*</sub>
