### PR TITLE
fix: catch webhook errors escaping grammy middleware pipeline

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -41,11 +41,16 @@ export function createBot(token: string): Bot {
     if (e instanceof GrammyError) {
       const desc = e.description;
 
-      // Unrecoverable chat errors — nothing to act on, skip silently
+      // Unrecoverable chat errors — log concisely, skip further handling
       if (
         (e.error_code === 400 && desc.includes('TOPIC_CLOSED')) ||
         (e.error_code === 403 && (desc.includes('kicked') || desc.includes('blocked')))
       ) {
+        const who = err.ctx.from?.username
+          ? `@${err.ctx.from.username}`
+          : String(err.ctx.from?.id ?? '?');
+        const where = err.ctx.chat?.title ?? String(err.ctx.chatId ?? '?');
+        console.warn(`[${e.method}] ${e.error_code} ${who} in "${where}": ${desc}`);
         return;
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { webhookCallback } from 'grammy';
+import { BotError, GrammyError, webhookCallback } from 'grammy';
 import { createBot } from './bot';
 import { config } from './config';
 
@@ -21,7 +21,17 @@ Bun.serve({
   async fetch(req) {
     const url = new URL(req.url);
     if (req.method === 'POST' && url.pathname === webhookPath) {
-      return handleUpdate(req);
+      try {
+        return await handleUpdate(req);
+      } catch (err) {
+        // ! Errors should already be logged by bot.catch — this catch
+        // ! only prevents Bun from dumping the full BotError object.
+        const e = err instanceof BotError ? err.error : err;
+        if (!(e instanceof GrammyError)) {
+          console.error('Webhook error:', e instanceof Error ? e.message : e);
+        }
+        return new Response('OK', { status: 200 });
+      }
     }
     if (url.pathname === '/health') {
       return new Response('OK');


### PR DESCRIPTION
The `bot.catch` handler already silences 403 kicked/blocked errors, but
rejected promises from `handleUpdate` propagated to `Bun.serve`, which
dumped the full `BotError` context object to stderr. Wrapping the call
in try-catch with `await` keeps the verbose output out of logs.

https://claude.ai/code/session_01T69M5EvJPB13ia34cGtgzo