### PR TITLE
feat: mark critical hits and fumbles in roll breakdowns #43

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -1,8 +1,22 @@
-import { DegreeOfSuccess, getErrorSpan, type RollParserError, type RollResult } from 'roll-parser';
+import {
+  DegreeOfSuccess,
+  type DieResult,
+  getErrorSpan,
+  type RollPart,
+  type RollParserError,
+  type RollResult,
+} from 'roll-parser';
 
 // ! Telegram rejects messages over 4096 chars — detailed replies fall back
 //   to the compact form beyond this threshold
 const MAX_DETAILED_LENGTH = 3500;
+
+const CRITICAL_MARK = '↑';
+const FUMBLE_MARK = '↓';
+
+// ? Every max face sets `critical`; below d6 the extremes come up too often for a
+//   mark to carry information.
+const MIN_MARKED_SIDES = 6;
 
 const DEGREE_LABELS: Record<DegreeOfSuccess, string> = {
   [DegreeOfSuccess.CriticalSuccess]: 'Critical Success',
@@ -35,6 +49,103 @@ function renderBreakdown(rendered: string): string {
  */
 function stripDiceNotation(rendered: string): string {
   return rendered.replace(/\d*d[^\s[]*(?=\[)/g, '');
+}
+
+type Marking = { critical: boolean; fumble: boolean; penetrating: boolean };
+
+const NO_MARKING: Marking = { critical: false, fumble: false, penetrating: false };
+
+/**
+ * What the notation says about marking a pool: which of `cs` / `cf` it spells out, and
+ * whether a penetrating explosion is in play. Declaring a threshold states interest in
+ * that extreme, so it lifts the die-size floor for that mark alone — `6d4cf` marks the
+ * 1s and leaves the 4s be.
+ */
+function readMarking(part: RollPart | undefined, found: Marking = { ...NO_MARKING }): Marking {
+  if (part == null) return found;
+
+  switch (part.type) {
+    case 'critThreshold':
+      found.critical ||= part.successThresholds.length > 0;
+      found.fumble ||= part.failThresholds.length > 0;
+      return readMarking(part.target, found);
+    case 'explode':
+      found.penetrating ||= part.variant === 'penetrating';
+      return readMarking(part.target, found);
+    case 'grouped':
+      return readMarking(part.inner, found);
+    case 'binaryOp':
+      return readMarking(part.right, readMarking(part.left, found));
+    case 'unaryOp':
+      return readMarking(part.operand, found);
+    case 'keepDrop':
+    case 'reroll':
+    case 'dieBound':
+    case 'successCount':
+    case 'sort':
+      return readMarking(part.target, found);
+    case 'versus':
+      return readMarking(part.dc, readMarking(part.roll, found));
+    case 'functionCall':
+      return part.args.reduce((acc, arg) => readMarking(arg, acc), found);
+    case 'group':
+      return part.parts.reduce((acc, child) => readMarking(child, acc), found);
+    default:
+      return found;
+  }
+}
+
+/**
+ * One die and its markers. The glyph goes inside the emphasis marker, so a die that is
+ * both a critical and a success renders `**20↑**` and Telegram carries the emphasis
+ * over the glyph.
+ *
+ * A die whose `result` was rewritten goes unmarked: `minN`/`maxN` and compound
+ * explosions stash the raw face in `initialResult`, a penetrating explosion decrements
+ * without recording anything, and the default rule flags the face rather than the number
+ * on screen — so `2d6max2` would otherwise show a critical `2`. An explicit `cs`/`cf`
+ * written outside the rewriting modifier (`2d6min5cs=5`) is scored on the shown value
+ * and loses its mark here; separating the two needs modifier order from the parts tree.
+ */
+function renderPoolDie(die: DieResult, marking: Marking): string {
+  const large = die.sides >= MIN_MARKED_SIDES;
+  const decremented = marking.penetrating && die.modifiers.includes('exploded');
+  const shown = die.initialResult == null && !decremented;
+
+  let rendered = String(die.result);
+  if (shown && die.critical && (large || marking.critical)) rendered += CRITICAL_MARK;
+  else if (shown && die.fumble && (large || marking.fumble)) rendered += FUMBLE_MARK;
+
+  if (die.modifiers.includes('dropped')) return `~~${rendered}~~`;
+  if (die.modifiers.includes('success')) return `**${rendered}**`;
+  if (die.modifiers.includes('failure')) return `__${rendered}__`;
+  return rendered;
+}
+
+/**
+ * Rewrites the dice bracket from `result.rolls`, the only place crit and fumble
+ * flags exist — the parser never writes them into `rendered`.
+ *
+ * Only a single-bracket breakdown is rewritten: part spans index the notation rather
+ * than the rendered string, so with several pools there is no telling which bracket a
+ * die belongs to. That also keeps out the DC side of a `vs` and pools fed by meta dice.
+ *
+ * A group keep/drop strikes a whole sub-roll — `{~~2d6[6, 3]~~, 5}` clears the
+ * one-bracket bar — where per-die `~~` would nest and `renderBreakdown` could not pair it.
+ */
+function markCritDice(result: RollResult, breakdown: string): string {
+  const first = breakdown.indexOf('[');
+  if (first === -1 || first !== breakdown.lastIndexOf('[')) return breakdown;
+  if (breakdown.slice(0, first).includes('~~')) return breakdown;
+
+  const pool = result.rolls.filter(
+    (die) => !die.modifiers.includes('meta') && !die.modifiers.includes('dc'),
+  );
+  if (pool.length === 0) return breakdown;
+
+  const marking = readMarking(result.parts);
+  const dice = pool.map((die) => renderPoolDie(die, marking)).join(', ');
+  return breakdown.replace(/\[[^\]]*\]/, `[${dice}]`);
 }
 
 function pluralize(count: number, word: string): string {
@@ -80,7 +191,8 @@ export function formatDetailedResult(result: RollResult): string {
 
   const tailIndex = result.rendered.lastIndexOf(' = ');
   const breakdown = tailIndex > 0 ? result.rendered.slice(0, tailIndex) : result.rendered;
-  const detailed = `${compact}\n${renderBreakdown(stripDiceNotation(breakdown))}`;
+  const marked = markCritDice(result, breakdown);
+  const detailed = `${compact}\n${renderBreakdown(stripDiceNotation(marked))}`;
 
   return detailed.length > MAX_DETAILED_LENGTH ? compact : detailed;
 }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -68,13 +68,13 @@ describe('formatResult', () => {
 describe('formatDetailedResult', () => {
   test('appends the die breakdown', () => {
     const result = roll('3d6', { rng: createMockRng([4, 2, 6]) });
-    expect(formatDetailedResult(result)).toBe('<code>3d6</code> = <b>12</b>\n[4, 2, 6]');
+    expect(formatDetailedResult(result)).toBe('<code>3d6</code> = <b>12</b>\n[4, 2, 6↑]');
   });
 
   test('strikes through dropped dice', () => {
     const result = roll('4d6kh3', { rng: createMockRng([3, 6, 2, 5]) });
     expect(formatDetailedResult(result)).toBe(
-      '<code>4d6kh3</code> = <b>14</b>\n[3, 6, <s>2</s>, 5]',
+      '<code>4d6kh3</code> = <b>14</b>\n[3, 6↑, <s>2</s>, 5]',
     );
   });
 
@@ -82,7 +82,7 @@ describe('formatDetailedResult', () => {
     const result = roll('5d10>=6f1', { rng: createMockRng([10, 2, 6, 1, 7]) });
     expect(formatDetailedResult(result)).toBe(
       '<code>5d10&gt;=6f1</code> = <b>3</b> successes, <b>1</b> failure\n' +
-        '[<b>10</b>, 2, <b>6</b>, <u>1</u>, <b>7</b>]',
+        '[<b>10↑</b>, 2, <b>6</b>, <u>1↓</u>, <b>7</b>]',
     );
   });
 
@@ -98,7 +98,145 @@ describe('formatDetailedResult', () => {
 
   test('keeps exploded dice attached to their group', () => {
     const result = roll('1d8!', { rng: createMockRng([8, 2]) });
-    expect(formatDetailedResult(result)).toBe('<code>1d8!</code> = <b>10</b>\n[8, 2]');
+    expect(formatDetailedResult(result)).toBe('<code>1d8!</code> = <b>10</b>\n[8↑, 2]');
+  });
+
+  test('marks a natural maximum and a natural 1', () => {
+    expect(formatDetailedResult(roll('1d20', { rng: createMockRng([20]) }))).toBe(
+      '<code>1d20</code> = <b>20</b>\n[20↑]',
+    );
+    expect(formatDetailedResult(roll('1d20', { rng: createMockRng([1]) }))).toBe(
+      '<code>1d20</code> = <b>1</b>\n[1↓]',
+    );
+  });
+
+  test('keeps meta dice out of the breakdown', () => {
+    const result = roll('(1d4)d6', { rng: createMockRng([2, 6, 3]) });
+    expect(formatDetailedResult(result)).toBe('<code>2d6</code> = <b>9</b>\n[6↑, 3]');
+  });
+
+  test('leaves multi-pool breakdowns unmarked', () => {
+    const result = roll('2d6+1d8', { rng: createMockRng([6, 3, 8]) });
+    expect(formatDetailedResult(result)).toBe('<code>2d6 + 1d8</code> = <b>17</b>\n[6, 3] + [8]');
+  });
+
+  test('leaves the dice of a versus comparison unmarked', () => {
+    const result = roll('1d20 vs 2d10', { rng: createMockRng([18, 5, 10]) });
+    expect(formatDetailedResult(result)).toBe(
+      '<code>1d20 vs 2d10</code> = <b>Success</b> (natural 18)\n[18] vs [5, 10]',
+    );
+  });
+
+  test('marks a critical sitting on a success', () => {
+    const result = roll('10d20>=10f<=3', {
+      rng: createMockRng([20, 9, 3, 16, 8, 15, 8, 13, 13, 14]),
+    });
+    expect(formatDetailedResult(result)).toBe(
+      '<code>10d20&gt;=10f&lt;=3</code> = <b>6</b> successes, <b>1</b> failure\n' +
+        '[<b>20↑</b>, 9, <u>3</u>, <b>16</b>, 8, <b>15</b>, 8, <b>13</b>, <b>13</b>, <b>14</b>]',
+    );
+  });
+
+  test('marks fumbles sitting on failures', () => {
+    const result = roll('10d10>=6f1', { rng: createMockRng([8, 4, 6, 5, 1, 5, 10, 9, 1, 9]) });
+    expect(formatDetailedResult(result)).toBe(
+      '<code>10d10&gt;=6f1</code> = <b>5</b> successes, <b>2</b> failures\n' +
+        '[<b>8</b>, 4, <b>6</b>, 5, <u>1↓</u>, 5, <b>10↑</b>, <b>9</b>, <u>1↓</u>, <b>9</b>]',
+    );
+  });
+
+  test('ignores small dice, whose extremes carry no information', () => {
+    expect(formatDetailedResult(roll('6d4', { rng: createMockRng([4, 2, 1, 4, 3, 1]) }))).toBe(
+      '<code>6d4</code> = <b>15</b>\n[4, 2, 1, 4, 3, 1]',
+    );
+    expect(
+      formatDetailedResult(roll('10d2', { rng: createMockRng([1, 2, 2, 1, 2, 1, 1, 2, 2, 1]) })),
+    ).toBe('<code>10d2</code> = <b>15</b>\n[1, 2, 2, 1, 2, 1, 1, 2, 2, 1]');
+  });
+
+  test('marks a small-dice pool once a threshold is declared', () => {
+    const result = roll('10d2cf', { rng: createMockRng([1, 2, 2, 1, 2, 1, 1, 2, 2, 1]) });
+    expect(formatDetailedResult(result)).toBe(
+      '<code>10d2cf</code> = <b>15</b>\n[1↓, 2, 2, 1↓, 2, 1↓, 1↓, 2, 2, 1↓]',
+    );
+  });
+
+  test('marks small dice for the extreme the notation declares', () => {
+    const faces = [4, 2, 1, 4, 3, 1];
+    expect(formatDetailedResult(roll('6d4cf', { rng: createMockRng(faces) }))).toBe(
+      '<code>6d4cf</code> = <b>15</b>\n[4, 2, 1↓, 4, 3, 1↓]',
+    );
+    expect(formatDetailedResult(roll('6d4cs', { rng: createMockRng(faces) }))).toBe(
+      '<code>6d4cs</code> = <b>15</b>\n[4↑, 2, 1, 4↑, 3, 1]',
+    );
+  });
+
+  test('honours a custom critical threshold', () => {
+    const result = roll('5d20cs>=15', { rng: createMockRng([14, 20, 6, 16, 15]) });
+    expect(formatDetailedResult(result)).toBe(
+      '<code>5d20cs&gt;=15</code> = <b>71</b>\n[14, 20↑, 6, 16↑, 15↑]',
+    );
+  });
+
+  test('leaves a compound explosion unmarked', () => {
+    const faces = [6, 6, 3];
+    expect(formatDetailedResult(roll('1d6!!', { rng: createMockRng(faces) }))).toBe(
+      '<code>1d6!!</code> = <b>15</b>\n[15]',
+    );
+    expect(formatDetailedResult(roll('1d6!!cs', { rng: createMockRng(faces) }))).toBe(
+      '<code>1d6!!cs</code> = <b>15</b>\n[15]',
+    );
+  });
+
+  test('leaves penetrating explosions unmarked past the first die', () => {
+    expect(formatDetailedResult(roll('1d20!p', { rng: createMockRng([20, 20, 5]) }))).toBe(
+      '<code>1d20!p</code> = <b>43</b>\n[20↑, 19, 4]',
+    );
+    expect(formatDetailedResult(roll('1d6!p', { rng: createMockRng([6, 1]) }))).toBe(
+      '<code>1d6!p</code> = <b>6</b>\n[6↑, 0]',
+    );
+  });
+
+  test('leaves a struck-through group sub-roll alone', () => {
+    expect(formatDetailedResult(roll('{2d6, 5}kl1', { rng: createMockRng([6, 3]) }))).toBe(
+      '<code>{2d6, 5}kl1</code> = <b>5</b>\n{<s>[6, 3]</s>, 5}',
+    );
+    expect(formatDetailedResult(roll('{1d20, 3}kh1', { rng: createMockRng([1]) }))).toBe(
+      '<code>{1d20, 3}kh1</code> = <b>3</b>\n{<s>[1]</s>, 3}',
+    );
+  });
+
+  test('marks the higher extreme when a die is both a critical and a fumble', () => {
+    const result = roll('4d20cs>=10cf<=15', { rng: createMockRng([12, 3, 18, 11]) });
+    expect(formatDetailedResult(result)).toBe(
+      '<code>4d20cs&gt;=10cf&lt;=15</code> = <b>44</b>\n[12↑, 3↓, 18↑, 11↑]',
+    );
+  });
+
+  test('leaves clamped dice unmarked, since the face rolled is not the one shown', () => {
+    expect(formatDetailedResult(roll('2d6min5', { rng: createMockRng([1, 6]) }))).toBe(
+      '<code>2d6min5</code> = <b>11</b>\n[5, 6↑]',
+    );
+    expect(formatDetailedResult(roll('2d6max2', { rng: createMockRng([6, 1]) }))).toBe(
+      '<code>2d6max2</code> = <b>3</b>\n[2, 1↓]',
+    );
+  });
+
+  test('marks each die of a standard explosion on its own face', () => {
+    const result = roll('1d6!', { rng: createMockRng([6, 3]) });
+    expect(formatDetailedResult(result)).toBe('<code>1d6!</code> = <b>9</b>\n[6↑, 3]');
+  });
+
+  test('marks the natural roll of a versus comparison', () => {
+    const result = roll('1d20 vs 15', { rng: createMockRng([20]) });
+    expect(formatDetailedResult(result)).toBe(
+      '<code>1d20 vs 15</code> = <b>Critical Success</b> (natural 20)\n[20↑] vs 15',
+    );
+  });
+
+  test('marks dice in sorted order', () => {
+    const result = roll('4d6s', { rng: createMockRng([3, 6, 1, 5]) });
+    expect(formatDetailedResult(result)).toBe('<code>4d6s</code> = <b>15</b>\n[1↓, 3, 5, 6↑]');
   });
 });
 


### PR DESCRIPTION
Criticals and fumbles now show in the detailed breakdown. The parser flags them on `DieResult` but never writes them into `rendered`, so a nat 20 rendered identically to a 14.

## Changes

- Added `markCritDice`, rewriting a single-bracket breakdown from `result.rolls`
- Appended `↑` / `↓` inside the emphasis marker, so a critical success renders `<b>20↑</b>`
- Marked `sides >= 6` by default, lifted per-mark by an explicit `cs` / `cf`
- Left dice whose `result` was rewritten unmarked — clamps, compound explosions, penetrating decrements
- Left pools behind a group keep/drop strike alone, where per-die `~~` would nest
- Updated 4 format tests, added 14

Telegram has no colour and no spare tags — `<b>`, `<u>` and `<s>` are already spent on success, failure and dropped, and `<code>` cannot nest with other entities — so the mark is a glyph rather than a tag. Multi-bracket breakdowns keep today's pipeline untouched, which excludes DC dice, struck group sub-rolls and meta dice rather than special-casing them. The cost: in `2d6+1d8` both maxima go unmarked, though each would be marked rolled alone.

## Known gaps

- An explicit `cs` / `cf` written outside a rewriting modifier (`2d6min5cs=5`) is scored on the shown value, so it loses a mark it asked for. Separating it from `2d6cs=5min5`, where suppression is correct, needs modifier order from the parts tree.
- `1d6!!cs` reports `critical: false` on a die that rolled its max face — edloidas/roll-parser#288, upstream.
- Pre-existing and untouched here: `{2d6}kh1` emits an unclosed brace, because `stripDiceNotation` eats the `}`.

Closes #43
