### PR TITLE
feat: localize the inline help button #45

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -5,7 +5,7 @@ import { fullReply } from './handlers/full';
 import { randomReply } from './handlers/random';
 import { helpReply } from './handlers/help';
 import { createInlineArticles } from './handlers/inline';
-import { resolveLocale } from './i18n';
+import { type Locale, messages, resolveLocale } from './i18n';
 import { normalizeNotation } from './notation';
 import { noPermissionText } from './text';
 
@@ -23,10 +23,9 @@ function logRoll(ctx: Context, command: string, notation: string, reply: string)
   console.log(`${name}${group} /${command}: ${notation} | ${result}`);
 }
 
-const INLINE_HELP_BUTTON: InlineQueryResultsButton = {
-  text: 'How to use',
-  start_parameter: 'help',
-};
+function inlineHelpButton(locale: Locale): InlineQueryResultsButton {
+  return { text: messages(locale).inline.help, start_parameter: 'help' };
+}
 
 function replyOptions(ctx: Context) {
   const isGroup = ctx.chat != null && GROUPS.includes(ctx.chat.type);
@@ -114,14 +113,12 @@ export function createBot(token: string): Bot {
   });
 
   bot.on('inline_query', async (ctx) => {
-    const { results, hasInvalidQuery } = createInlineArticles(
-      ctx.inlineQuery.query,
-      resolveLocale(ctx.from?.language_code),
-    );
+    const locale = resolveLocale(ctx.from?.language_code);
+    const { results, hasInvalidQuery } = createInlineArticles(ctx.inlineQuery.query, locale);
     await ctx.answerInlineQuery(results, {
       cache_time: 0,
       is_personal: true,
-      ...(hasInvalidQuery ? { button: INLINE_HELP_BUTTON } : {}),
+      ...(hasInvalidQuery ? { button: inlineHelpButton(locale) } : {}),
     });
   });
 

--- a/src/locales/be.ts
+++ b/src/locales/be.ts
@@ -2,7 +2,7 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const be: Messages = {
-  inline: { roll: 'Кідок', full: 'Падрабязны', random: 'Выпадковы' },
+  inline: { roll: 'Кідок', full: 'Падрабязны', random: 'Выпадковы', help: 'Як карыстацца' },
 
   help: `Кідай кубікі як ніхто іншы — поўная ролевая натацыя: захаванне/скід, выбуховыя кубікі, перакіды, пулы поспехаў і праверкі.
 

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -2,7 +2,7 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const de: Messages = {
-  inline: { roll: 'Wurf', full: 'Aufschlüsselung', random: 'Zufallswurf' },
+  inline: { roll: 'Wurf', full: 'Aufschlüsselung', random: 'Zufallswurf', help: 'Anleitung' },
 
   help: `Würfle wie noch nie — vollständige Rollenspiel-Notation mit Behalten/Verwerfen, explodierenden Würfeln, Wiederholungswürfen, Erfolgspools und Proben.
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -2,7 +2,7 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const en: Messages = {
-  inline: { roll: 'Roll', full: 'Full', random: 'Random' },
+  inline: { roll: 'Roll', full: 'Full', random: 'Random', help: 'How to use' },
 
   help: `Roll the dice like no one before — full RPG notation with keep/drop, exploding dice, rerolls, success pools, and checks.
 

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -2,7 +2,7 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const es: Messages = {
-  inline: { roll: 'Tirada', full: 'Desglose', random: 'Aleatoria' },
+  inline: { roll: 'Tirada', full: 'Desglose', random: 'Aleatoria', help: 'Cómo se usa' },
 
   help: `Tira los dados como nadie — notación de rol completa con mantener/descartar, dados explosivos, nuevas tiradas, reservas de éxitos y pruebas.
 

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -2,7 +2,7 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const pt: Messages = {
-  inline: { roll: 'Rolagem', full: 'Detalhada', random: 'Aleatória' },
+  inline: { roll: 'Rolagem', full: 'Detalhada', random: 'Aleatória', help: 'Como usar' },
 
   help: `Role os dados como ninguém — notação de RPG completa com manter/descartar, dados explosivos, novas rolagens, reservas de sucessos e testes.
 

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -2,7 +2,7 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const ru: Messages = {
-  inline: { roll: 'Бросок', full: 'Разбор', random: 'Наугад' },
+  inline: { roll: 'Бросок', full: 'Разбор', random: 'Наугад', help: 'Как пользоваться' },
 
   help: `Бросай кубики как никто другой — полная ролевая нотация: оставить/отбросить, взрывающиеся кубики, перебросы, пулы успехов и проверки.
 

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -4,8 +4,8 @@ export interface CommandText {
 }
 
 export interface Messages {
-  /** Inline result titles — they mirror the commands they stand for. */
-  inline: { roll: string; full: string; random: string };
+  /** Inline result titles mirroring the commands they stand for, plus the help button above them. */
+  inline: { roll: string; full: string; random: string; help: string };
   help: string;
   commands: CommandText[];
   /** Profile blurb shown in search — Telegram caps it at 120 characters. */

--- a/src/locales/uk.ts
+++ b/src/locales/uk.ts
@@ -2,7 +2,7 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const uk: Messages = {
-  inline: { roll: 'Кидок', full: 'Докладно', random: 'Випадковий' },
+  inline: { roll: 'Кидок', full: 'Докладно', random: 'Випадковий', help: 'Як користуватися' },
 
   help: `Кидай кубики як ніхто інший — повна рольова нотація: утримання/відкидання, вибухові кубики, перекидання, пул успіху і перевірки.
 

--- a/test/handlers/inline.test.ts
+++ b/test/handlers/inline.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
   bot = new TestBot();
 });
 
-const HELP_BUTTON = { text: 'How to use', start_parameter: 'help' };
+const HELP_BUTTON = { text: messages('en').inline.help, start_parameter: 'help' };
 
 const PRESET_ARTICLES = [
   { title: 'Roll', description: 'd20' },
@@ -152,6 +152,19 @@ describe('Inline queries', () => {
     test('should not show help button for extended notation', async () => {
       await bot.sendInline('2d20kh1+5');
       expect(bot.inlineResults[0].button).toBeUndefined();
+    });
+
+    test('should localize the help button for the requesting user', async () => {
+      await bot.sendInline('abc', 'ru');
+      expect(bot.inlineResults[0].button).toEqual({
+        text: messages('ru').inline.help,
+        start_parameter: 'help',
+      });
+    });
+
+    test('should fall back to the English help button for unsupported languages', async () => {
+      await bot.sendInline('abc', 'ja');
+      expect(bot.inlineResults[0].button).toEqual(HELP_BUTTON);
     });
   });
 


### PR DESCRIPTION
Added `inline.help` to the `Messages` contract and translated it in all seven locales.

Replaced the `INLINE_HELP_BUTTON` module constant with a per-locale `inlineHelpButton` builder, and hoisted the resolved locale in the `inline_query` handler so the articles and the button share one lookup.

Covered the localized and unsupported-language button in `test/handlers/inline.test.ts`.

Closes #45
