### PR TITLE
improvement: prefix inline result IDs to expose chosen variant #41

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -24,6 +24,12 @@ function logRoll(ctx: Context, command: string, notation: string, reply: string)
   console.log(`${name}${group} /${command}: ${notation} | ${result}`);
 }
 
+/** Result IDs are `<variant>:<uuid>`; unprefixed IDs predate that and cannot be attributed. */
+function inlineVariant(resultId: string): string {
+  const separator = resultId.indexOf(':');
+  return separator > 0 ? resultId.slice(0, separator) : 'unknown';
+}
+
 function inlineHelpButton(locale: Locale): InlineQueryResultsButton {
   return { text: messages(locale).inline.help, start_parameter: 'help' };
 }
@@ -113,7 +119,8 @@ export function createBot(token: string): Bot {
   bot.on('chosen_inline_result', (ctx) => {
     const name = ctx.from?.username ? `@${ctx.from.username}` : (ctx.from?.first_name ?? 'unknown');
     const query = ctx.chosenInlineResult.query || 'd20';
-    console.log(`${name} [inline]: ${query}`);
+    const variant = inlineVariant(ctx.chosenInlineResult.result_id);
+    console.log(`${name} [inline] ${variant}: ${query}`);
   });
 
   bot.on('inline_query', async (ctx) => {

--- a/src/handlers/inline.ts
+++ b/src/handlers/inline.ts
@@ -14,10 +14,18 @@ function createInputMessageContent(text: string) {
   };
 }
 
-function createArticle(title: string, description: string, message: string): InlineQueryResult {
+type InlineVariant = 'roll' | 'full' | 'random';
+
+function createArticle(
+  variant: InlineVariant,
+  title: string,
+  description: string,
+  message: string,
+): InlineQueryResult {
   return {
     type: 'article',
-    id: crypto.randomUUID(),
+    // Prefix exposes the chosen variant in `chosen_inline_result.result_id`
+    id: `${variant}:${crypto.randomUUID()}`,
     title,
     input_message_content: createInputMessageContent(message),
     description,
@@ -44,8 +52,8 @@ function createVariantArticles(
   label?: string | null,
 ): InlineQueryResult[] {
   return [
-    createArticle(titles.roll, description, withLabel(formatResult(result), label)),
-    createArticle(titles.full, description, withLabel(formatDetailedResult(result), label)),
+    createArticle('roll', titles.roll, description, withLabel(formatResult(result), label)),
+    createArticle('full', titles.full, description, withLabel(formatDetailedResult(result), label)),
   ];
 }
 
@@ -61,7 +69,7 @@ function createQueryArticles(
 function createPresetArticles(titles: Messages['inline']): InlineQueryResult[] {
   return [
     ...createVariantArticles(roll(DEFAULT_NOTATION), DEFAULT_NOTATION, titles),
-    createArticle(titles.random, RANDOM_NOTATION, formatTotal(roll(RANDOM_NOTATION))),
+    createArticle('random', titles.random, RANDOM_NOTATION, formatTotal(roll(RANDOM_NOTATION))),
   ];
 }
 

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { TestBot } from './helpers';
 
 let bot: TestBot;
@@ -44,5 +44,32 @@ describe('Bot message options', () => {
     expect(await bot.send('/roll@testbot d20')).toMatch(pattern);
     expect(await bot.send('/full@testbot d20')).toMatch(pattern);
     expect(await bot.send('/random@testbot')).toMatch(/^<b>\d{1,3}<\/b>$/);
+  });
+});
+
+describe('Chosen inline results', () => {
+  let log: ReturnType<typeof spyOn<Console, 'log'>>;
+
+  beforeEach(() => {
+    log = spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    log.mockRestore();
+  });
+
+  async function chosenLog(resultId: string, query = ''): Promise<string> {
+    await bot.sendChosenInline(resultId, query);
+    return log.mock.calls.at(-1)?.[0] ?? '';
+  }
+
+  test('should log the chosen variant', async () => {
+    expect(await chosenLog('roll:abc', 'd20')).toEqual('@testuser [inline] roll: d20');
+    expect(await chosenLog('full:abc', 'd20')).toEqual('@testuser [inline] full: d20');
+    expect(await chosenLog('random:abc')).toEqual('@testuser [inline] random: d20');
+  });
+
+  test('should log an unknown variant for unprefixed ids', async () => {
+    expect(await chosenLog('abc', 'd20')).toEqual('@testuser [inline] unknown: d20');
   });
 });

--- a/test/handlers/inline.test.ts
+++ b/test/handlers/inline.test.ts
@@ -51,6 +51,21 @@ describe('Inline queries', () => {
     expectArticles(results, PRESET_ARTICLES);
   });
 
+  test('should prefix preset article ids with their variant', async () => {
+    const results = await bot.sendInline('');
+    expect(results.map((r) => r.id.split(':')[0])).toEqual(['roll', 'full', 'random']);
+  });
+
+  test('should prefix query article ids with their variant', async () => {
+    const results = await bot.sendInline('d20');
+    expect(results.map((r) => r.id.split(':')[0])).toEqual(['roll', 'full']);
+  });
+
+  test('should keep article ids unique within a response', async () => {
+    const results = await bot.sendInline('');
+    expect(new Set(results.map((r) => r.id)).size).toEqual(results.length);
+  });
+
   test('should return compact and detailed articles for valid notation', async () => {
     const results = await bot.sendInline('d20');
     expectArticles(results, [

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -53,6 +53,17 @@ function createInlineQueryUpdate(query: string, languageCode?: string) {
   };
 }
 
+function createChosenInlineResultUpdate(resultId: string, query: string) {
+  return {
+    update_id: nextUpdateId(),
+    chosen_inline_result: {
+      result_id: resultId,
+      query,
+      from: createSender(),
+    },
+  };
+}
+
 export class TestBot {
   bot: Bot;
   replies: any[] = [];
@@ -109,6 +120,12 @@ export class TestBot {
     const update = createInlineQueryUpdate(query, languageCode);
     await this.bot.handleUpdate(update as any);
     return this.inlineResults[0]?.results || [];
+  }
+
+  async sendChosenInline(resultId: string, query = ''): Promise<void> {
+    this.clear();
+    const update = createChosenInlineResultUpdate(resultId, query);
+    await this.bot.handleUpdate(update as any);
   }
 
   getLastReplyOptions(): any {


### PR DESCRIPTION
Inline result IDs are now `<variant>:<uuid>` instead of a bare UUID, so `chosen_inline_result.result_id` reveals which of the three articles a user picked.

- `createArticle` takes an `InlineVariant` (`roll` | `full` | `random`) and prefixes the generated UUID
- `chosen_inline_result` reads the variant back by splitting on the first `:` and logs it, falling back to `unknown` for unprefixed IDs
- Added a `sendChosenInline` test helper; covered the ID prefixes, per-response uniqueness, and the log output

`cache_time: 0` is unchanged.

Closes #41
