### PR TITLE
feat: add Farsi locale with RTL handling #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ full [notation reference](https://roll-parser.edloidas.io/reference).
 #### Languages: ####
 
 Inline titles, the command menu, and the notation guide follow your Telegram language:
-English, Spanish, Portuguese, German, Russian, Ukrainian, and Belarusian. Anything else
-falls back to English. Roll results are notation, so they read the same everywhere.
+English, Spanish, Portuguese, German, Russian, Ukrainian, Belarusian, and Persian.
+Anything else falls back to English. Roll results are notation, so they read the same
+everywhere.
 
 Your ideas on improvement are welcome.
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -25,8 +25,20 @@ const DEGREE_LABELS: Record<DegreeOfSuccess, string> = {
   [DegreeOfSuccess.CriticalFailure]: 'Critical Failure',
 };
 
+// ! Direction controls survive HTML escaping and reorder everything after them, so a reply
+//   could show text its sender never wrote. Excludes ZWNJ and ZWJ, which Persian needs.
+const BIDI_CONTROL = /\p{Bidi_Control}/gu;
+
+function nameControl(char: string): string {
+  return `U+${char.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')}`;
+}
+
 export function escapeHtml(text: string): string {
-  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(BIDI_CONTROL, nameControl);
 }
 
 /**
@@ -204,6 +216,11 @@ export function formatDetailedResult(result: RollResult): string {
 
 type CaretSpan = { start: number; end: number };
 
+// ! Carets are placed by code-unit offset, so they only land right when every character is
+//   one code unit and one column, rendered where it is stored. Right-to-left runs,
+//   combining marks, and wide or astral characters break that; these scripts do not.
+const CARETABLE = /^[\x20-\x7e\p{Script=Latin}\p{Script=Cyrillic}\p{Script=Greek}]*$/u;
+
 /** Clamps the parser's span to the echoed notation, so the carets always land on it. */
 function resolveCaretSpan(error: RollParserError, length: number): CaretSpan | null {
   const span = getErrorSpan(error);
@@ -216,14 +233,15 @@ function resolveCaretSpan(error: RollParserError, length: number): CaretSpan | n
 
 /**
  * Error reply: the parser message plus the notation echoed in a `pre` block
- * with the offending span underlined by carets. Multiline notation skips the
- * echo — caret alignment only works on a single line.
+ * with the offending span underlined by carets. Notation the carets cannot be
+ * aligned against still gets its echo, just without the caret line. Multiline
+ * notation skips the echo outright — there is no single line to point at.
  */
 export function formatError(error: RollParserError, notation: string): string {
   const message = `<i>${escapeHtml(error.message)}.</i>`;
   if (notation === '' || notation.includes('\n')) return message;
 
-  const span = resolveCaretSpan(error, notation.length);
+  const span = CARETABLE.test(notation) ? resolveCaretSpan(error, notation.length) : null;
   if (span == null) return `${message}\n<pre>${escapeHtml(notation)}</pre>`;
 
   const carets = `${' '.repeat(span.start)}${'^'.repeat(span.end - span.start)}`;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,6 +2,7 @@ import { be } from './locales/be';
 import { de } from './locales/de';
 import { en } from './locales/en';
 import { es } from './locales/es';
+import { fa } from './locales/fa';
 import { pt } from './locales/pt';
 import { ru } from './locales/ru';
 import type { Messages } from './locales/types';
@@ -11,7 +12,7 @@ export type { Messages } from './locales/types';
 
 export const DEFAULT_LOCALE = 'en';
 
-const MESSAGES = { en, es, pt, de, ru, uk, be } satisfies Record<string, Messages>;
+const MESSAGES = { en, es, pt, de, ru, uk, be, fa } satisfies Record<string, Messages>;
 
 export type Locale = keyof typeof MESSAGES;
 

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -1,0 +1,66 @@
+import { playground, reference } from './links';
+import type { Messages } from './types';
+
+// ! Line structure is load-bearing here — do not reflow. Anything holding notation, a
+//   `/command` or an `@mention` must open with a Latin character, or the line resolves
+//   right-to-left and strands the leading `/` or `@` at the far end. Notation must not
+//   follow Persian directly either: an Arabic letter reclassifies the digit after it and
+//   splits `2d10-1` in two. All of it assumes the client resolves direction per line.
+
+export const fa: Messages = {
+  inline: { roll: 'پرتاب', full: 'جزئیات', random: 'پرتاب تصادفی', help: 'راهنما' },
+
+  help: `مثل هیچ‌کس دیگری تاس بینداز — نمادگذاری کامل بازی‌های نقش‌آفرینی: نگه‌داشتن و کنار گذاشتن، تاس انفجاری، پرتاب مجدد، شمارش موفقیت‌ها و چک در برابر درجهٔ سختی.
+
+<b>دستورها</b>
+/roll 2d20+5 — پرتاب و نمایش مجموع، میان‌بر /r
+/full 4d6kh3 — پرتاب با جزئیات هر تاس، میان‌بر /f
+/random — پرتاب تاس d100 (<code>d%</code>)
+/help — همین راهنما
+
+Inline: @rollrobot را در هر گفت‌وگو همراه با نمادگذاری بنویس، یا از فهرست انتخاب کن
+
+<b>نمادگذاری</b>
+<code>2d20+5</code> — تاس و محاسبات: + - * / و پرانتز
+<code>4d6kh3</code> — نگه‌داشتن سه تاس با بالاترین مقدار، همچنین (kl, dh, dl)
+<code>d8!</code> — تاس انفجاری
+<code>2d6r&lt;3</code> — پرتاب مجدد مقادیر کمتر از سه (ro — فقط یک پرتاب مجدد)
+<code>4d6min2</code> — حداقل مقدار هر تاس دو می‌شود، همچنین (max)
+<code>6d10&gt;=6f1</code> — شمارش موفقیت‌ها، یک‌ها به‌عنوان شکست کم می‌شوند
+<code>1d20+7 vs 15</code> — چک در برابر درجهٔ سختی، با درجات موفقیت
+<code>4dF</code> — تاس Fate، <code>d%</code> — تاس درصدی
+<code>2d6+floor(1d4/2)</code> — توابع: floor, ceil, round, abs, min, max, sqrt, pow
+
+<code>/roll 20</code> — کوتاه‌نویسی، همان d20
+<code>2d10-1</code> — با کوتاه‌نویسی <code>/roll 2 10 -1</code>
+
+<code>/roll 2d20+1 «ادراک»</code>
+نام پرتاب را داخل گیومه و در پایان بنویس.
+
+نمادگذاری را در ${playground('محیط آزمایش')} امتحان کن، یا ${reference('راهنمای کامل نمادگذاری')} را بخوان.`,
+
+  commands: [
+    { command: 'roll', description: '/roll 2d20kh1+5 — پرتاب تاس' },
+    { command: 'full', description: '/full 4d6kh3 — پرتاب با جزئیات' },
+    { command: 'random', description: '/random — پرتاب تاس d100' },
+    { command: 'help', description: 'راهنمای نمادگذاری و پیوندها' },
+  ],
+
+  shortDescription:
+    'تاس نقش‌آفرینی رومیزی در هر گفت‌وگو — D&D, Pathfinder, World of Darkness, Shadowrun, Fate',
+
+  description: `نمادگذاری تاس برای بازی‌های نقش‌آفرینی رومیزی، در هر گفت‌وگو.
+
+4d6kh3 برای ویژگی‌ها
+2d20kh1+7 با برتری
+1d20+12 vs 20 برای چک در Pathfinder
+7d10>=6f1 برای مجموعهٔ تاس Storyteller
+{1d8!, 1d6!}kh1 برای Savage Worlds
+4dF برای Fate، d% برای Call of Cthulhu
+
+/roll — مجموع را می‌دهد
+/full — جزئیات هر تاس
+/help — راهنمای نمادگذاری
+
+@rollrobot را در هر گفت‌وگو بنویس تا بدون افزودن ربات تاس بیندازی`,
+};

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -1,14 +1,38 @@
 const BARE_NUMBER = /^\d+$/;
 const SIMPLIFIED = /^(\d+)\s+(\d+)(?:\s+([+-]?\d+))?$/;
 
+const EASTERN_NUMERALS = /[٠-٩٪۰-۹]/g;
+
+const ARABIC_INDIC_ZERO = 0x0660;
+const EXTENDED_ARABIC_INDIC_ZERO = 0x06f0;
+const ARABIC_PERCENT = 0x066a;
+
+/**
+ * Folds Arabic-Indic (`٠`–`٩`), Extended Arabic-Indic (`۰`–`۹`) and the Arabic percent
+ * sign (`٪`) to ASCII, which is all the parser's grammar accepts.
+ *
+ * ! Notation only. `extractLabel` runs first at every call site, so a roll named
+ * `«ضربهٔ ۳»` keeps its own numerals — folding ahead of that split would renumber it.
+ */
+function foldNumerals(input: string): string {
+  return input.replace(EASTERN_NUMERALS, (char) => {
+    const code = char.charCodeAt(0);
+    if (code === ARABIC_PERCENT) return '%';
+    const zero = code < ARABIC_PERCENT ? ARABIC_INDIC_ZERO : EXTENDED_ARABIC_INDIC_ZERO;
+    return String(code - zero);
+  });
+}
+
 /**
  * Rewrites pre-v3 shorthand into dice notation: a bare number rolls a die
  * with that many sides (`20` → `d20`), and the space-separated simplified
  * form becomes classic notation (`2 10 -1` → `2d10-1`). Anything else is
  * passed through for the parser to judge. Empty input defaults to `d20`.
+ *
+ * Eastern numerals are folded first, so the shorthand rules see `۲۰` as `20`.
  */
 export function normalizeNotation(input: string): string {
-  const trimmed = input.trim();
+  const trimmed = foldNumerals(input.trim());
   if (trimmed === '') return 'd20';
 
   if (BARE_NUMBER.test(trimmed)) return `d${trimmed}`;

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -267,4 +267,49 @@ describe('formatError', () => {
     const message = formatError(rollError('2d6+\n&'), '2d6+\n&');
     expect(message).toMatch(/^<i>.+\.<\/i>$/);
   });
+
+  // Carets are placed by code-unit offset, which a right-to-left run reorders away from
+  test('drops the caret line for right-to-left notation, keeping the echo', () => {
+    expect(formatError(rollError('2d20 ضربه'), '2d20 ضربه')).toBe(
+      "<i>Unexpected character: 'ض'.</i>\n<pre>2d20 ضربه</pre>",
+    );
+    expect(formatError(rollError('2d20 בדיקה'), '2d20 בדיקה')).toBe(
+      "<i>Unexpected character: 'ב'.</i>\n<pre>2d20 בדיקה</pre>",
+    );
+  });
+
+  // A tab is not one column wide, so carets under it would land short
+  test('drops the caret line for tabs, keeping the echo', () => {
+    expect(formatError(rollError('2d6\t&'), '2d6\t&')).toBe(
+      "<i>Unexpected character: '&amp;'.</i>\n<pre>2d6\t&amp;</pre>",
+    );
+  });
+
+  // Cyrillic is single-column and single-code-unit, so offsets still line up. `в` sits on
+  // the `d` key, which makes this the likeliest typo a Russian-layout user makes.
+  test('keeps the caret line for single-width non-ASCII', () => {
+    const message = formatError(rollError('2в20'), '2в20');
+    expect(message).toMatch(/^<i>.+\.<\/i>\n<pre>2в20\n \^<\/pre>$/);
+  });
+
+  // ! An override reorders the reply without appearing in it, so it is named rather than
+  //   echoed — otherwise a roll could display text its sender never wrote.
+  test('names bidi controls instead of passing them through', () => {
+    const overridden = '2d20\u202Eabc';
+    const message = formatError(rollError(overridden), overridden);
+    expect(message).toContain('U+202E');
+    expect(message).not.toMatch(/\p{Bidi_Control}/u);
+  });
+});
+
+describe('escapeHtml direction controls', () => {
+  test('names every direction control it finds', () => {
+    expect(escapeHtml('a‮b‏c⁦d')).toBe('aU+202EbU+200FcU+2066d');
+  });
+
+  // Persian orthography depends on ZWNJ, which is not a direction control
+  test('leaves ZWNJ and ZWJ alone', () => {
+    expect(escapeHtml('می‌اندازد')).toBe('می‌اندازد');
+    expect(escapeHtml('a‍b')).toBe('a‍b');
+  });
 });

--- a/test/handlers/roll.test.ts
+++ b/test/handlers/roll.test.ts
@@ -94,5 +94,13 @@ describe('/roll', () => {
       expect(reply).not.toContain('<blockquote>');
       expect(reply).toMatch(/^<i>.+<\/i>/);
     });
+
+    // ! Pins the split-then-fold order through the real command path — folding ahead of
+    //   `extractLabel` would renumber every Persian roll title.
+    test('should fold eastern numerals in the notation but not in the label', async () => {
+      const reply = await bot.send('/roll ۲d۶ «ضربهٔ ۳»');
+      expect(reply).toContain('<blockquote>ضربهٔ ۳</blockquote>');
+      expect(reply).toContain('<code>2d6</code>');
+    });
   });
 });

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -2,10 +2,22 @@ import { describe, test, expect } from 'bun:test';
 import {
   DEFAULT_LOCALE,
   type Locale,
+  type Messages,
   messages,
   resolveLocale,
   SUPPORTED_LOCALES,
 } from '../src/i18n';
+
+/** Every user-visible string in a dictionary, for checks that apply to all of them. */
+function allText(entry: Messages): string[] {
+  return [
+    ...Object.values(entry.inline),
+    entry.help,
+    entry.shortDescription,
+    entry.description,
+    ...entry.commands.map((command) => command.description),
+  ];
+}
 
 describe('resolveLocale', () => {
   test('matches a supported two-letter code', () => {
@@ -19,6 +31,8 @@ describe('resolveLocale', () => {
     expect(resolveLocale('pt-br')).toBe('pt');
     expect(resolveLocale('es-419')).toBe('es');
     expect(resolveLocale('en-GB')).toBe('en');
+    expect(resolveLocale('fa-IR')).toBe('fa');
+    expect(resolveLocale('fa-AF')).toBe('fa');
   });
 
   test('is case-insensitive', () => {
@@ -36,7 +50,7 @@ describe('resolveLocale', () => {
 
 describe('messages', () => {
   test('covers every advertised locale', () => {
-    expect(SUPPORTED_LOCALES).toEqual(['en', 'es', 'pt', 'de', 'ru', 'uk', 'be']);
+    expect(SUPPORTED_LOCALES).toEqual(['en', 'es', 'pt', 'de', 'ru', 'uk', 'be', 'fa']);
   });
 
   for (const locale of SUPPORTED_LOCALES) {
@@ -57,6 +71,14 @@ describe('messages', () => {
         for (const { description } of entry.commands) {
           expect(description.length).toBeGreaterThan(0);
           expect(description.length).toBeLessThanOrEqual(256);
+        }
+      });
+
+      // Direction comes from line structure, never from invisible overrides. ZWNJ and ZWJ
+      // are orthography, not direction, so Persian keeps them.
+      test('carries no bidi control characters', () => {
+        for (const text of allText(entry)) {
+          expect(text).not.toMatch(/[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/u);
         }
       });
 
@@ -93,4 +115,54 @@ describe('messages', () => {
       });
     });
   }
+});
+
+// Persian is the only right-to-left dictionary, so these cover what no other one can hit
+describe('fa', () => {
+  const entry = messages('fa');
+
+  // `@` strands at the far end of a mention the same way `/` does on a command, so a line
+  // carrying either needs the Latin anchor
+  const NOTATION_LINE = /\/(roll|full|random|help|r|f)\b|\d*d[\d%F]|@\w/;
+
+  test('uses Persian letter forms rather than Arabic ones', () => {
+    for (const text of allText(entry)) {
+      expect(text).not.toMatch(/[يكةى]/u);
+    }
+  });
+
+  // Notation examples have to stay copy-pasteable into a roll, and the parser is ASCII
+  test('writes every numeral in ASCII', () => {
+    for (const text of allText(entry)) {
+      expect(text).not.toMatch(/[٠-٩۰-۹]/u);
+    }
+  });
+
+  // A line takes its direction from the first strong character. Open one right-to-left and
+  // the leading `/` detaches, so `/roll 2d20kh1+5` reaches the reader as `roll 2d20kh1+5/`.
+  const directionalLines = [entry.help, entry.description]
+    .flatMap((text) => text.split('\n'))
+    .concat(entry.commands.map((command) => command.description))
+    .map((line) => line.replace(/<[^>]+>/g, ''))
+    .filter((line) => NOTATION_LINE.test(line));
+
+  test('opens every notation line with a Latin character', () => {
+    for (const line of directionalLines) {
+      const strong = line.match(/\p{Script=Latin}|\p{Script=Arabic}/u);
+      expect(strong?.[0]).toMatch(/\p{Script=Latin}/u);
+    }
+  });
+
+  test('finds the notation lines it means to check', () => {
+    expect(directionalLines.length).toBeGreaterThan(20);
+  });
+
+  // ! Guillemets carry no Bidi_Paired_Bracket_Type, so a pair split across an LTR run and
+  //   an RTL one resolves to different levels and the closing mark renders mirrored.
+  test('keeps a quoted example clear of the prose that explains it', () => {
+    for (const line of entry.help.split('\n')) {
+      if (!line.includes('«')) continue;
+      expect(line.replace(/<[^>]+>/g, '')).toMatch(/^\S+[^»]*»$/u);
+    }
+  });
 });

--- a/test/label.test.ts
+++ b/test/label.test.ts
@@ -67,6 +67,10 @@ describe('extractLabel', () => {
     });
   });
 
+  test('leaves eastern numerals in the label alone', () => {
+    expect(extractLabel('2d6 «ضربهٔ ۳»')).toEqual({ notation: '2d6', label: 'ضربهٔ ۳' });
+  });
+
   test('trims whitespace around both halves', () => {
     expect(extractLabel('  2d6   "  spaced  "  ')).toEqual({ notation: '2d6', label: 'spaced' });
   });

--- a/test/notation.test.ts
+++ b/test/notation.test.ts
@@ -19,6 +19,27 @@ describe('normalizeNotation', () => {
     expect(normalizeNotation('2 10 3')).toBe('2d10+3');
   });
 
+  // Persian and Arabic keyboards emit their own numerals, which the ASCII-only
+  // parser grammar and the shorthand rules above would otherwise reject
+  test('folds eastern numerals to ASCII', () => {
+    expect(normalizeNotation('۲۰')).toBe('d20');
+    expect(normalizeNotation('٢٠')).toBe('d20');
+    expect(normalizeNotation('۲ ۱۰ -۱')).toBe('2d10-1');
+    expect(normalizeNotation('٢ ١٠ -١')).toBe('2d10-1');
+    expect(normalizeNotation('۲d۲۰+۵')).toBe('2d20+5');
+    expect(normalizeNotation('۴d۶kh۳')).toBe('4d6kh3');
+  });
+
+  test('folds every digit in both eastern ranges', () => {
+    expect(normalizeNotation('d۰۱۲۳۴۵۶۷۸۹')).toBe('d0123456789');
+    expect(normalizeNotation('d٠١٢٣٤٥٦٧٨٩')).toBe('d0123456789');
+  });
+
+  // Shift+5 on the standard Persian layout, so `d٪` is what a percentile roll looks like
+  test('folds the arabic percent sign', () => {
+    expect(normalizeNotation('d٪')).toBe('d%');
+  });
+
   test('passes dice notation through untouched', () => {
     expect(normalizeNotation('d20')).toBe('d20');
     expect(normalizeNotation('4d6kh3')).toBe('4d6kh3');


### PR DESCRIPTION
Adds Persian as the eighth locale and the first right-to-left one.

- Added `src/locales/fa.ts` and registered `fa` in `MESSAGES`. Direction comes from line structure rather than bidi control characters: every line carrying notation, a `/command` or an `@mention` opens with a Latin character.
- Folded Arabic-Indic and Extended Arabic-Indic numerals, plus the Arabic percent sign, to ASCII at the top of `normalizeNotation`. It runs after `extractLabel` at every call site, so a roll named `«ضربهٔ ۳»` keeps its own numerals.
- Replaced `formatError`'s multiline echo guard with `CARETABLE`. Notation the carets cannot be aligned against keeps its `<pre>` echo and loses only the caret line; Cyrillic and Greek still get carets.
- Named bidi controls as `U+XXXX` in `escapeHtml`. They survive HTML escaping and reorder everything after them, so a roll label could otherwise render text its sender never wrote.
- Added structural tests: a Latin anchor on every directional line, no bidi controls in any locale, and no Arabic letter forms or eastern numerals in `fa`.

Outcome labels, parser error messages and `noPermissionText` stay English for all eight locales, as scoped in the issue.

Closes #50
