### PR TITLE
release: v3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rollrobot",
   "private": true,
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Roll Robot is a Telegram bot for dice rolling.",
   "keywords": ["rollrobot", "telegram", "bot", "roll", "dice", "random"],
   "homepage": "https://github.com/edloidas/rollrobot",


### PR DESCRIPTION
Bumps `version` to 3.2.0.

Ships #39 — roll analytics to Analytics Engine — and #50, the Farsi locale.

Tag `v3.2.0` is applied after merge; `release.yml` then validates, deploys the Worker, and creates the GitHub Release.