### PR TITLE
fix: log d100 for inline random rolls

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -11,7 +11,7 @@ import { rollReply } from './handlers/roll';
 import { fullReply } from './handlers/full';
 import { RANDOM_NOTATION, randomReply } from './handlers/random';
 import { helpReply } from './handlers/help';
-import { chosenInlineRoll, createInlineArticles } from './handlers/inline';
+import { chosenInlineRoll, createInlineArticles, DEFAULT_NOTATION } from './handlers/inline';
 import { type Locale, messages, resolveLocale } from './i18n';
 import { extractLabel } from './label';
 import { normalizeNotation } from './notation';
@@ -147,7 +147,8 @@ export function createBot(env: BotEnv): Bot {
     const name = senderName(ctx);
     const { query, result_id } = ctx.chosenInlineResult;
     const variant = inlineVariant(result_id);
-    console.log(`${name} [inline] ${variant}: ${query || 'd20'}`);
+    const notation = variant === 'random' ? RANDOM_NOTATION : query || DEFAULT_NOTATION;
+    console.log(`${name} [inline] ${variant}: ${notation}`);
 
     const context = { command: 'inline', surface: 'inline', userId: ctx.from?.id } as const;
     await trackRoll(env, context, () => chosenInlineRoll(query, variant));

--- a/src/handlers/inline.ts
+++ b/src/handlers/inline.ts
@@ -33,7 +33,7 @@ function createArticle(
   };
 }
 
-const DEFAULT_NOTATION = 'd20';
+export const DEFAULT_NOTATION = 'd20';
 
 function tryRoll(notation: string): RollResult | null {
   try {

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -66,7 +66,11 @@ describe('Chosen inline results', () => {
   test('should log the chosen variant', async () => {
     expect(await chosenLog('roll:abc', 'd20')).toEqual('@testuser [inline] roll: d20');
     expect(await chosenLog('full:abc', 'd20')).toEqual('@testuser [inline] full: d20');
-    expect(await chosenLog('random:abc')).toEqual('@testuser [inline] random: d20');
+    expect(await chosenLog('random:abc')).toEqual('@testuser [inline] random: d100');
+  });
+
+  test('should log the default notation for an empty query', async () => {
+    expect(await chosenLog('roll:abc')).toEqual('@testuser [inline] roll: d20');
   });
 
   test('should log an unknown variant for unprefixed ids', async () => {


### PR DESCRIPTION
Inline console logs printed `query || 'd20'` for every variant, so a chosen `random` result was logged as `d20` while it actually rolls `d100`.

- Log `RANDOM_NOTATION` for the `random` variant, `DEFAULT_NOTATION` otherwise
- Exported `DEFAULT_NOTATION` from `handlers/inline` instead of duplicating the literal