### PR TITLE
feat: add HTML render target to the analytics report #57

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 coverage/
 dist/
 temp/
+.tmp/
 .wrangler/
 
 # AI

--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ bun run analytics -- quota            # data points per day against the 100k/day
 bun run analytics -- sql "SELECT 1"   # one-off query
 ```
 
+The report renders as `table` (default), `json`, or `html`:
+
+```sh
+bun run analytics -- --format html --out .tmp/report.html
+```
+
+The page is self-contained — inline styles, hand-written SVG, no network access and no
+build step — and reads `.analytics/` when it is populated, so it can show more history than
+the live retention window. Charts are withheld rather than faked where the data cannot
+support them: a series shorter than three days renders as its table instead of a trend line,
+and a cohort with no eligible users reads `n/a` rather than `0%`.
+
 ### Reading the numbers
 
 Every table is tagged with how far it can be trusted, because none of the three failure

--- a/scripts/analytics/charts.ts
+++ b/scripts/analytics/charts.ts
@@ -1,0 +1,253 @@
+/**
+ * Hand-written SVG marks. No charting library: the whole page has to open from
+ * disk with no network, and the four forms used here are a few dozen lines each.
+ *
+ * Mark specs are fixed — 2px lines, bars capped at 24px with a 4px rounded data
+ * end squared at the baseline, markers at r>=4 wearing a 2px surface ring, and
+ * hairline solid gridlines one step off the surface.
+ */
+
+export const BAR_THICKNESS = 16;
+export const ROW_HEIGHT = 26;
+
+/** Separates touching fills — a gap in the surface color, never a stroke. */
+const SURFACE_GAP = 2;
+
+export function esc(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function compact(value: number): string {
+  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (Math.abs(value) >= 10_000) return `${(value / 1000).toFixed(1)}K`;
+  return value.toLocaleString('en-US');
+}
+
+export function percent(value: number, digits = 1): string {
+  return `${(value * 100).toFixed(digits)}%`;
+}
+
+/**
+ * Rounds an axis maximum up to something a reader can hold in their head.
+ *
+ * ! The step never drops below 2. The mid gridline is drawn at half the maximum
+ *   and its label is rounded, so an odd maximum would put the line at 3.5 and
+ *   label it 4 — a gridline that lies about where it sits.
+ */
+export function niceMax(value: number): number {
+  if (value <= 0) return 1;
+  const magnitude = Math.max(2, 10 ** Math.floor(Math.log10(value)));
+  return Math.ceil(value / magnitude) * magnitude;
+}
+
+/** Square at the baseline, rounded at the value end — the end that carries meaning. */
+function barPath(x: number, y: number, width: number, height: number): string {
+  const radius = Math.min(4, Math.max(0, width), height / 2);
+  if (width <= radius) return `M${x},${y}h${width}v${height}h${-width}z`;
+
+  return [
+    `M${x},${y}`,
+    `H${x + width - radius}`,
+    `A${radius},${radius} 0 0 1 ${x + width} ${y + radius}`,
+    `V${y + height - radius}`,
+    `A${radius},${radius} 0 0 1 ${x + width - radius} ${y + height}`,
+    `H${x}`,
+    'Z',
+  ].join(' ');
+}
+
+/** Rough advance width at the 12px label size — enough to keep text off the edge. */
+const CHAR_WIDTH = 6.2;
+
+/**
+ * Category labels are anchored to the right of their column and grow leftward, so
+ * an over-long one runs out of the viewBox and over the card. Truncating keeps the
+ * chart intact; the full text stays in the hover title and the table twin.
+ */
+function fit(label: string, budget: number): string {
+  const limit = Math.floor(budget / CHAR_WIDTH);
+  return label.length <= limit ? label : `${label.slice(0, Math.max(1, limit - 1))}…`;
+}
+
+export interface BarRow {
+  label: string;
+  value: number;
+  /** Formatted figure shown at the tip. */
+  display: string;
+  /** Emphasis: `false` drops the row to the de-emphasis gray. */
+  strong?: boolean;
+  title?: string;
+}
+
+/**
+ * Horizontal bars for magnitude across nominal categories — one hue for every
+ * bar, because bar length already encodes the value and a ramp would spend the
+ * only free channel restating it. `strong: false` is the emphasis exception.
+ */
+export function barChart(rows: BarRow[], labelWidth = 132): string {
+  if (rows.length === 0) return '<p class="empty">No rows in this window.</p>';
+
+  const width = 640;
+  const height = rows.length * ROW_HEIGHT;
+  const max = Math.max(...rows.map((row) => row.value), 1);
+  const trackStart = labelWidth + 8;
+  const trackWidth = width - trackStart - 56;
+
+  const marks = rows.map((row, index) => {
+    const y = index * ROW_HEIGHT + (ROW_HEIGHT - BAR_THICKNESS) / 2;
+    // A zero draws nothing: a 1px stub for "none" is a bar that misstates its value
+    const barWidth = row.value === 0 ? 0 : Math.max(1, (row.value / max) * trackWidth);
+    const fill = row.strong === false ? 'var(--de-emphasis)' : 'var(--series-1)';
+
+    return [
+      `<g><title>${esc(row.title ?? `${row.label}: ${row.display}`)}</title>`,
+      `<text class="cat" x="${labelWidth}" y="${y + BAR_THICKNESS / 2}" text-anchor="end" dominant-baseline="central">${esc(fit(row.label, labelWidth))}</text>`,
+      barWidth > 0
+        ? `<path d="${barPath(trackStart, y, barWidth, BAR_THICKNESS)}" fill="${fill}" />`
+        : '',
+      `<text class="val" x="${trackStart + barWidth + 8}" y="${y + BAR_THICKNESS / 2}" dominant-baseline="central">${esc(row.display)}</text>`,
+      '</g>',
+    ].join('');
+  });
+
+  return `<svg class="chart" viewBox="0 0 ${width} ${height}" role="img" preserveAspectRatio="xMinYMin meet">${marks.join('')}</svg>`;
+}
+
+export interface Segment {
+  label: string;
+  value: number;
+  share: number;
+  color: string;
+  /**
+   * Class picking the in-fill label ink. A label sitting on a colored fill is the
+   * one place text takes its color from the mark, and it has to be chosen by the
+   * fill's luminance — white on the aqua or yellow slot measures under 3:1.
+   */
+  labelClass: string;
+}
+
+/**
+ * One stacked bar for part-to-whole. Segments are separated by a gap in the
+ * surface color rather than a stroke, and a segment is only labelled inline when
+ * the text measurably fits — a clipped label is worse than none, and the value
+ * is in the table twin either way.
+ */
+export function stackedBar(segments: Segment[]): string {
+  if (segments.length === 0) return '<p class="empty">No rows in this window.</p>';
+
+  const width = 640;
+  const height = 34;
+  const total = segments.reduce((sum, segment) => sum + segment.value, 0) || 1;
+
+  // ! Positions come from the running total, never from accumulating spans. Adding
+  //   a gap per segment walks the last one past the viewBox once several segments
+  //   are narrower than the gap itself.
+  let consumed = 0;
+  const marks = segments.map((segment) => {
+    const start = (consumed / total) * width;
+    consumed += segment.value;
+    const end = (consumed / total) * width;
+    const span = Math.max(0, end - start - SURFACE_GAP);
+
+    const label = percent(segment.share, 0);
+    // ~7px per char at this size, plus 16px of padding either side
+    const fits = span > label.length * 7 + 16;
+
+    return [
+      `<g><title>${esc(`${segment.label}: ${compact(segment.value)} (${percent(segment.share)})`)}</title>`,
+      `<rect x="${start}" y="0" width="${span}" height="${height}" fill="${segment.color}" rx="2" />`,
+      fits
+        ? `<text class="on-fill ${segment.labelClass}" x="${start + span / 2}" y="${height / 2}" text-anchor="middle" dominant-baseline="central">${esc(label)}</text>`
+        : '',
+      '</g>',
+    ].join('');
+  });
+
+  return `<svg class="chart" viewBox="0 0 ${width} ${height}" role="img" preserveAspectRatio="none" style="height:${height}px">${marks.join('')}</svg>`;
+}
+
+export interface SeriesPoint {
+  day: string;
+  value: number;
+  /** Frozen days come from snapshots and outlive the query window. */
+  frozen: boolean;
+}
+
+/**
+ * A single series over time. Two points cannot show a trend, so the caller is
+ * expected to withhold this form below three — see `trendIsReadable`.
+ */
+export function lineChart(points: SeriesPoint[]): string {
+  const width = 640;
+  const height = 200;
+  const padding = { top: 12, right: 12, bottom: 26, left: 44 };
+  const plotWidth = width - padding.left - padding.right;
+  const plotHeight = height - padding.top - padding.bottom;
+
+  const max = niceMax(Math.max(...points.map((point) => point.value), 1));
+  const stepX = points.length > 1 ? plotWidth / (points.length - 1) : 0;
+  const at = (index: number, value: number) => ({
+    x: padding.left + (points.length > 1 ? index * stepX : plotWidth / 2),
+    y: padding.top + plotHeight - (value / max) * plotHeight,
+  });
+
+  const coords = points.map((point, index) => at(index, point.value));
+
+  const gridlines = [0, 0.5, 1].map((fraction) => {
+    const y = padding.top + plotHeight - fraction * plotHeight;
+    return [
+      `<line class="grid" x1="${padding.left}" y1="${y}" x2="${width - padding.right}" y2="${y}" />`,
+      `<text class="tick" x="${padding.left - 8}" y="${y}" text-anchor="end" dominant-baseline="central">${compact(Math.round(max * fraction))}</text>`,
+    ].join('');
+  });
+
+  const line = coords.map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x},${point.y}`);
+  const area = [
+    ...line,
+    `L${coords[coords.length - 1].x},${padding.top + plotHeight}`,
+    `L${coords[0].x},${padding.top + plotHeight}`,
+    'Z',
+  ];
+
+  // Only the ends get a tick; a label under every day collides on a 90-day window
+  const axis = [0, points.length - 1]
+    .filter((index, position, all) => all.indexOf(index) === position && index >= 0)
+    .map(
+      (index) =>
+        `<text class="tick" x="${coords[index].x}" y="${height - 6}" text-anchor="${index === 0 ? 'start' : 'end'}">${esc(points[index].day)}</text>`,
+    );
+
+  const dots = points.map((point, index) => {
+    const { x, y } = coords[index];
+    return [
+      `<g><title>${esc(`${point.day}: ${compact(point.value)}${point.frozen ? ' (frozen snapshot)' : ''}`)}</title>`,
+      `<circle cx="${x}" cy="${y}" r="4" fill="var(--series-1)" stroke="var(--surface-1)" stroke-width="2" />`,
+      '</g>',
+    ].join('');
+  });
+
+  // The label rides above its point, except when the series peaks last — there it
+  // would sit outside the viewBox, so it drops below the point instead
+  const last = coords[coords.length - 1];
+  const labelY = last.y - 12 < padding.top ? last.y + 18 : last.y - 12;
+
+  return [
+    `<svg class="chart" viewBox="0 0 ${width} ${height}" role="img" preserveAspectRatio="xMinYMin meet">`,
+    gridlines.join(''),
+    `<path d="${area.join(' ')}" fill="var(--series-1)" fill-opacity="0.1" />`,
+    `<path d="${line.join(' ')}" fill="none" stroke="var(--series-1)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />`,
+    dots.join(''),
+    `<text class="val" x="${last.x - 6}" y="${labelY}" text-anchor="end">${compact(points[points.length - 1].value)}</text>`,
+    axis.join(''),
+    '</svg>',
+  ].join('');
+}
+
+/** Below three points a line reads as a confident slope it has not earned. */
+export function trendIsReadable(points: SeriesPoint[]): boolean {
+  return points.length >= 3;
+}

--- a/scripts/analytics/html.ts
+++ b/scripts/analytics/html.ts
@@ -1,0 +1,408 @@
+import {
+  barChart,
+  type BarRow,
+  compact,
+  esc,
+  lineChart,
+  percent,
+  type Segment,
+  type SeriesPoint,
+  stackedBar,
+  trendIsReadable,
+} from './charts';
+import type { Metric, Report } from './report';
+import type { DaySnapshot } from './snapshot';
+
+/**
+ * Categorical slots 1-4, validated as a set against both surfaces. The order is
+ * the colourblind-safety mechanism, not a preference — do not resequence without
+ * re-validating. Aqua and yellow fall below 3:1 on the light surface, which is why
+ * every segment carries a visible label and every chart carries a table twin.
+ */
+const SERIES = [
+  { fill: 'var(--series-1)', labelClass: 'ink-light' },
+  { fill: 'var(--series-2)', labelClass: 'ink-dark' },
+  { fill: 'var(--series-3)', labelClass: 'ink-dark' },
+  { fill: 'var(--series-4)', labelClass: 'ink-dark' },
+];
+
+const STYLE = `
+:root {
+  color-scheme: light;
+  --surface-1: #fcfcfb;
+  --plane: #f9f9f7;
+  --text-primary: #0b0b0b;
+  --text-secondary: #52514e;
+  --muted: #898781;
+  --grid: #e1e0d9;
+  --border: rgba(11, 11, 11, 0.1);
+  --de-emphasis: #c3c2b7;
+  --series-1: #2a78d6;
+  --series-2: #eb6834;
+  --series-3: #1baf7a;
+  --series-4: #eda100;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --surface-1: #1a1a19;
+    --plane: #0d0d0d;
+    --text-primary: #ffffff;
+    --text-secondary: #c3c2b7;
+    --muted: #898781;
+    --grid: #2c2c2a;
+    --border: rgba(255, 255, 255, 0.1);
+    --de-emphasis: #52514e;
+    --series-1: #3987e5;
+    --series-2: #d95926;
+    --series-3: #199e70;
+    --series-4: #c98500;
+  }
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  padding: 40px 24px 80px;
+  background: var(--plane);
+  color: var(--text-primary);
+  font: 14px/1.55 system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+main { max-width: 860px; margin: 0 auto; }
+h1 { font-size: 20px; font-weight: 600; margin: 0 0 4px; }
+h2 { font-size: 15px; font-weight: 600; margin: 0 0 2px; }
+p { margin: 0; }
+.sub { color: var(--text-secondary); font-size: 13px; }
+.muted { color: var(--muted); font-size: 12px; }
+
+.caveats {
+  margin: 24px 0 32px;
+  padding: 16px 18px;
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+.caveats dt { font-weight: 600; font-size: 12px; margin-top: 10px; }
+.caveats dt:first-of-type { margin-top: 0; }
+.caveats dd { margin: 0; color: var(--text-secondary); font-size: 12px; }
+
+.hero { margin: 0 0 28px; }
+.hero .figure { font-size: 48px; font-weight: 600; line-height: 1.1; letter-spacing: -0.02em; }
+
+.kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin-bottom: 32px; }
+.kpi { background: var(--surface-1); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; }
+.kpi .label { color: var(--text-secondary); font-size: 12px; }
+.kpi .value { font-size: 24px; font-weight: 600; margin-top: 2px; }
+
+.card { background: var(--surface-1); border: 1px solid var(--border); border-radius: 10px; padding: 18px 20px; margin-bottom: 20px; }
+.card header { margin-bottom: 14px; }
+.tag {
+  display: inline-block; margin-left: 8px; padding: 1px 7px; border-radius: 999px;
+  background: var(--plane); border: 1px solid var(--border);
+  color: var(--text-secondary); font-size: 11px; font-weight: 500; vertical-align: 2px;
+}
+.warn { color: var(--text-secondary); font-size: 12px; margin-top: 8px; }
+
+.chart { width: 100%; height: auto; overflow: visible; display: block; }
+.chart .cat { fill: var(--text-secondary); font-size: 12px; }
+.chart .val { fill: var(--text-primary); font-size: 12px; font-weight: 500; }
+.chart .tick { fill: var(--muted); font-size: 11px; font-variant-numeric: tabular-nums; }
+.chart .grid { stroke: var(--grid); stroke-width: 1; }
+.chart .on-fill { font-size: 11px; font-weight: 600; }
+/* Chosen by each fill's luminance, so both clear 3:1 in either mode */
+.chart .ink-light { fill: #ffffff; }
+.chart .ink-dark { fill: #0b0b0b; }
+
+.legend { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 12px; }
+.legend span { display: inline-flex; align-items: center; gap: 6px; color: var(--text-secondary); font-size: 12px; }
+.legend i { width: 10px; height: 10px; border-radius: 3px; display: inline-block; }
+
+details { margin-top: 14px; }
+summary { cursor: pointer; color: var(--text-secondary); font-size: 12px; }
+.scroll { overflow-x: auto; }
+table { border-collapse: collapse; width: 100%; margin-top: 10px; font-size: 12px; }
+th, td { text-align: left; padding: 5px 12px 5px 0; border-bottom: 1px solid var(--grid); white-space: nowrap; }
+th { color: var(--text-secondary); font-weight: 600; }
+td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+.empty { color: var(--muted); font-size: 13px; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+`;
+
+function tag<Value>(metric: Metric<Value>): string {
+  return `<span class="tag">${esc(metric.precision)}</span>`;
+}
+
+function caveatLine<Value>(metric: Metric<Value>): string {
+  return metric.caveat ? `<p class="warn">! ${esc(metric.caveat)}</p>` : '';
+}
+
+function table(columns: string[], rows: (string | number)[][], numeric: number[] = []): string {
+  if (rows.length === 0) return '<p class="empty">No rows in this window.</p>';
+
+  const head = columns
+    .map(
+      (column, index) => `<th${numeric.includes(index) ? ' class="num"' : ''}>${esc(column)}</th>`,
+    )
+    .join('');
+  const body = rows
+    .map(
+      (row) =>
+        `<tr>${row.map((cell, index) => `<td${numeric.includes(index) ? ' class="num"' : ''}>${esc(String(cell))}</td>`).join('')}</tr>`,
+    )
+    .join('');
+
+  return `<div class="scroll"><table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table></div>`;
+}
+
+/** Every chart ships its values as text too, so nothing is reachable by colour alone. */
+function twin(columns: string[], rows: (string | number)[][], numeric: number[] = []): string {
+  return `<details><summary>Table view</summary>${table(columns, rows, numeric)}</details>`;
+}
+
+function card(title: string, tagged: string, body: string, note = ''): string {
+  return `<section class="card"><header><h2>${esc(title)}${tagged}</h2>${note}</header>${body}</section>`;
+}
+
+function addDays(day: string, count: number): string {
+  return new Date(Date.parse(`${day}T00:00:00Z`) + count * 86_400_000).toISOString().slice(0, 10);
+}
+
+/**
+ * Frozen days win over the live query wherever they overlap: a snapshot is the
+ * settled record of a day, while the live window re-estimates it under sampling
+ * every run.
+ *
+ * ! Gaps are filled with zeroes. The query returns no row for a day nobody rolled,
+ *   and the chart spaces points by position — so an unfilled gap would draw a
+ *   fortnight of silence as one step, and read as a smooth trend.
+ */
+function rollSeries(report: Report, snapshots: DaySnapshot[]): SeriesPoint[] {
+  const byDay = new Map<string, SeriesPoint>();
+  for (const day of report.metrics.rollsPerDay.value) {
+    byDay.set(day.day, { day: day.day, value: day.n, frozen: false });
+  }
+  for (const snapshot of snapshots) {
+    byDay.set(snapshot.day, { day: snapshot.day, value: snapshot.rolls, frozen: true });
+  }
+
+  const days = [...byDay.keys()].sort();
+  if (days.length === 0) return [];
+
+  const filled: SeriesPoint[] = [];
+  const last = days[days.length - 1];
+  for (let day = days[0]; day <= last; day = addDays(day, 1)) {
+    filled.push(byDay.get(day) ?? { day, value: 0, frozen: false });
+  }
+
+  return filled;
+}
+
+export function renderHtml(report: Report, snapshots: DaySnapshot[]): string {
+  const { window, metrics } = report;
+  const users = metrics.users.value;
+  const modifiers = metrics.modifiers.value;
+  const series = rollSeries(report, snapshots);
+
+  // The hero states the window the subtitle names. The chart may reach further back
+  // through snapshots, but summing that would answer a question nobody asked.
+  const windowRolls = metrics.rollsPerDay.value.reduce((sum, day) => sum + day.n, 0);
+  const inlineShare = metrics.surfaces.value.find((row) => row.key === 'inline')?.share ?? 0;
+
+  const liveDays = new Set(metrics.rollsPerDay.value.map((day) => day.day));
+  const addedDays = series.filter((point) => point.frozen && !liveDays.has(point.day)).length;
+
+  const activity = trendIsReadable(series)
+    ? lineChart(series)
+    : `<p class="empty">${series.length} day${series.length === 1 ? '' : 's'} of data — too few to read as a trend. The table view below carries the values.</p>`;
+
+  const systems: BarRow[] = metrics.systems.value.map((row) => ({
+    label: row.label,
+    value: row.n,
+    display: percent(row.share, 0),
+    strong: row.confidence === 'strong',
+    title: `${row.label}: ${compact(row.n)} terms (${percent(row.share)}), ${row.confidence} signal`,
+  }));
+
+  // ! Part-to-whole has to show the whole. There are six possible surfaces and four
+  //   slots, so the tail folds into one segment rather than being dropped — cutting
+  //   it would rescale the survivors and put every segment out of step with its label.
+  const ranked = metrics.surfaces.value;
+  const folded =
+    ranked.length > SERIES.length
+      ? [
+          ...ranked.slice(0, SERIES.length - 1),
+          {
+            key: 'other',
+            n: ranked.slice(SERIES.length - 1).reduce((sum, row) => sum + row.n, 0),
+            share: ranked.slice(SERIES.length - 1).reduce((sum, row) => sum + row.share, 0),
+          },
+        ]
+      : ranked;
+
+  const surfaces: Segment[] = folded.map((row, index) => ({
+    label: row.key,
+    value: row.n,
+    share: row.share,
+    color: SERIES[index].fill,
+    labelClass: SERIES[index].labelClass,
+  }));
+
+  const buckets: BarRow[] = metrics.buckets.value.map((row) => ({
+    label: row.key,
+    value: row.n,
+    display: percent(row.share, 0),
+  }));
+
+  const tokens: BarRow[] = metrics.modifierTokens.value.map((row) => ({
+    label: row.token,
+    value: row.n,
+    display: compact(row.n),
+  }));
+
+  const cohort = (label: string, value: { eligible: number; rate: number }) =>
+    value.eligible === 0
+      ? `${label}: n/a (no cohort old enough yet)`
+      : `${label}: ${percent(value.rate)} of ${value.eligible}`;
+
+  const body = [
+    '<main>',
+    `<h1>rollrobot analytics</h1>`,
+    `<p class="sub">${esc(window.first || 'no data')} .. ${esc(window.last || '')} · last ${window.days} days${addedDays > 0 ? ` · charts reach back ${addedDays} day${addedDays === 1 ? '' : 's'} further through snapshots` : ''}</p>`,
+    `<p class="muted">Generated ${esc(report.generatedAt)}</p>`,
+
+    '<div class="caveats"><dl>',
+    ...Object.entries(report.precisionNotes).map(
+      ([key, note]) => `<dt>${esc(key)}</dt><dd>${esc(note)}</dd>`,
+    ),
+    `<dt>inline</dt><dd>${esc(metrics.surfaces.caveat ?? '')}</dd>`,
+    '</dl></div>',
+
+    ...report.warnings.map((warning) => `<p class="warn">! ${esc(warning)}</p>`),
+
+    `<div class="hero"><p class="sub">Rolls recorded in the last ${window.days} days</p><p class="figure">${compact(windowRolls)}</p></div>`,
+
+    '<div class="kpis">',
+    `<div class="kpi"><p class="label">Users observed rolling</p><p class="value">${compact(users.observedUsers)}</p></div>`,
+    `<div class="kpi"><p class="label">Dice terms per roll</p><p class="value">${metrics.termsPerRoll.value.toFixed(2)}</p></div>`,
+    `<div class="kpi"><p class="label">Terms with a modifier</p><p class="value">${percent(modifiers.rate)}</p></div>`,
+    `<div class="kpi"><p class="label">Calls sent inline</p><p class="value">${percent(inlineShare, 0)}</p></div>`,
+    '</div>',
+
+    card(
+      'Rolls per day',
+      tag(metrics.rollsPerDay),
+      activity +
+        twin(
+          ['Day', 'Rolls', 'Source'],
+          series.map((point) => [point.day, point.value, point.frozen ? 'snapshot' : 'live']),
+          [1],
+        ),
+      caveatLine(metrics.rollsPerDay),
+    ),
+
+    card(
+      'Game system signals',
+      tag(metrics.systems),
+      barChart(systems, 168) +
+        `<div class="legend"><span><i style="background:var(--series-1)"></i>strong — a modifier or die makes the shape distinctive</span><span><i style="background:var(--de-emphasis)"></i>weak — the shape fits, but fits others too</span></div>` +
+        twin(
+          ['Signal', 'Confidence', 'Terms', 'Share'],
+          metrics.systems.value.map((row) => [
+            row.label,
+            row.confidence,
+            row.n,
+            percent(row.share),
+          ]),
+          [2, 3],
+        ),
+      '<p class="muted">Constants are not recorded, so 4d6kh3 and 4d6kh1 arrive identical. These are signals, not detections.</p>',
+    ),
+
+    card(
+      'Where the bot is used',
+      tag(metrics.surfaces),
+      stackedBar(surfaces) +
+        `<div class="legend">${surfaces.map((segment) => `<span><i style="background:${segment.color}"></i>${esc(segment.label)}</span>`).join('')}</div>` +
+        twin(
+          ['Surface', 'Calls', 'Share'],
+          metrics.surfaces.value.map((row) => [row.key, row.n, percent(row.share)]),
+          [1, 2],
+        ),
+      '<p class="muted">Counts every invocation, including /help and /start — not only rolls.</p>' +
+        caveatLine(metrics.surfaces),
+    ),
+
+    card(
+      'Die sizes',
+      tag(metrics.buckets),
+      barChart(buckets, 60) +
+        twin(
+          ['Bucket', 'Points', 'Share'],
+          metrics.buckets.value.map((row) => [row.key, row.n, percent(row.share)]),
+          [1, 2],
+        ),
+    ),
+
+    card(
+      'Modifier adoption',
+      tag(metrics.modifiers),
+      `<p class="sub">${compact(modifiers.modified)} of ${compact(modifiers.total)} terms carry a modifier (${percent(modifiers.rate)}).</p>` +
+        (tokens.length > 0
+          ? barChart(tokens, 60)
+          : '<p class="empty">No modifiers recorded in this window.</p>') +
+        twin(
+          ['Token', 'Terms', 'Share'],
+          metrics.modifierTokens.value.map((row) => [row.token, row.n, percent(row.share)]),
+          [1, 2],
+        ),
+    ),
+
+    card(
+      'Notation shapes',
+      tag(metrics.notation),
+      table(
+        ['Term', 'Modifiers', 'Terms'],
+        metrics.notation.value.slice(0, 20).map((row) => [row.term, row.modifiers || '—', row.n]),
+        [2],
+      ),
+    ),
+
+    card(
+      'Users',
+      tag(metrics.users),
+      `<p class="sub">${cohort('D1 return', users.cohorts.d1)} · ${cohort('D7 return', users.cohorts.d7)}</p>` +
+        (users.firstDay
+          ? `<p class="warn">! users first seen on ${esc(users.firstDay)} may have rolled before the window opened, so they are excluded from the cohorts</p>`
+          : '') +
+        table(
+          ['Top share', 'Users', 'Of all rolls'],
+          users.concentration.map((row) => [`top ${row.percent}%`, row.users, percent(row.share)]),
+          [1, 2],
+        ) +
+        twin(
+          ['Active days', 'Users'],
+          users.activityHistogram.map((row) => [row.activeDays, row.users]),
+          [0, 1],
+        ),
+      caveatLine(metrics.users),
+    ),
+
+    '</main>',
+  ];
+
+  return [
+    '<!doctype html>',
+    '<html lang="en">',
+    '<head>',
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    '<title>rollrobot analytics</title>',
+    `<style>${STYLE}</style>`,
+    '</head>',
+    '<body>',
+    body.join(''),
+    '</body>',
+    '</html>',
+    '',
+  ].join('\n');
+}

--- a/scripts/analytics/index.ts
+++ b/scripts/analytics/index.ts
@@ -1,10 +1,14 @@
 import { parseArgs } from 'node:util';
 import { type AnalyticsClient, createClient } from './client';
+import { renderHtml } from './html';
 import { fetchLatestRows, fetchPointsPerDay } from './queries';
 import { buildReport, preamble, renderReport } from './report';
-import { RETENTION_DAYS, SNAPSHOT_DIR, writeSnapshots } from './snapshot';
+import { readSnapshots, RETENTION_DAYS, SNAPSHOT_DIR, writeSnapshots } from './snapshot';
 
 const DEFAULT_DAYS = 30;
+
+const FORMATS = ['table', 'json', 'html'] as const;
+type Format = (typeof FORMATS)[number];
 
 /** Free-plan write allowance, the ceiling the volume check is read against. */
 const DAILY_ALLOWANCE = 100_000;
@@ -19,7 +23,9 @@ Commands:
 
 Options:
   --days <n>         window in days (default ${DEFAULT_DAYS}, max ${RETENTION_DAYS})
-  --json             emit JSON instead of tables
+  --format <f>       ${FORMATS.join(' | ')} (default table); html needs --out
+  --out <path>       file to write the html report to
+  --json             shorthand for --format json
   --snapshot         freeze every complete day not yet in ${SNAPSHOT_DIR}/
 `;
 
@@ -104,6 +110,8 @@ async function main(): Promise<void> {
     args: Bun.argv.slice(2),
     options: {
       days: { type: 'string' },
+      format: { type: 'string' },
+      out: { type: 'string' },
       json: { type: 'boolean', default: false },
       snapshot: { type: 'boolean', default: false },
       help: { type: 'boolean', default: false },
@@ -121,17 +129,36 @@ async function main(): Promise<void> {
     throw new Error(`--days must be a positive number, got "${values.days}"`);
   }
 
+  const format = (values.format ?? (values.json ? 'json' : 'table')) as Format;
+  if (!FORMATS.includes(format)) {
+    throw new Error(`--format must be one of ${FORMATS.join(', ')}, got "${values.format}"`);
+  }
+  if (format === 'html' && !values.out) {
+    throw new Error('--format html needs --out, e.g. --out .tmp/report.html');
+  }
+
+  // Caveats belong on the page itself for html, and in the payload for json
+  const quiet = format !== 'table';
+
   const client = createClient();
   const [command, argument] = positionals;
+
+  // Only the report has enough shape to be worth a page; the rest are line output.
+  // Without the --snapshot arm here, --out would be demanded and then ignored.
+  if (format === 'html' && (command != null || values.snapshot)) {
+    throw new Error(
+      `--format html applies to the report, not "${command ?? '--snapshot'}"\n\n${USAGE}`,
+    );
+  }
 
   if (values.snapshot) {
     if (command != null) {
       throw new Error(`--snapshot takes no command, but got "${command}"\n\n${USAGE}`);
     }
 
-    printCaveats(values.json, 'err');
+    printCaveats(quiet, 'err');
     const outcome = await writeSnapshots(client);
-    print(values.json, outcome, () =>
+    print(quiet, outcome, () =>
       [
         `snapshots in ${SNAPSHOT_DIR}/`,
         `  wrote ${outcome.written.length}: ${outcome.written.join(' ') || '-'}`,
@@ -145,16 +172,23 @@ async function main(): Promise<void> {
   switch (command) {
     case undefined: {
       const report = await buildReport(client, days);
-      print(values.json, report, () => renderReport(report));
+      if (format === 'html') {
+        const out = values.out as string;
+        await Bun.write(out, renderHtml(report, readSnapshots()));
+        console.log(`Wrote ${out}`);
+        return;
+      }
+
+      print(format === 'json', report, () => renderReport(report));
       return;
     }
     case 'doctor':
-      return runDoctor(client, Number(argument ?? 20), values.json);
+      return runDoctor(client, Number(argument ?? 20), quiet);
     case 'quota':
-      return runQuota(client, days, values.json);
+      return runQuota(client, days, quiet);
     case 'sql': {
       if (!argument) throw new Error('sql needs a query, e.g. analytics sql "SELECT 1"');
-      printCaveats(values.json, 'err');
+      printCaveats(quiet, 'err');
       console.log(JSON.stringify(await client.query(argument), null, 2));
       return;
     }

--- a/scripts/analytics/snapshot.ts
+++ b/scripts/analytics/snapshot.ts
@@ -1,7 +1,6 @@
-import { existsSync, mkdirSync, readdirSync, renameSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync } from 'node:fs';
 import type { AnalyticsClient } from './client';
 import {
-  DAILY_NOTATION_LIMIT,
   fetchDailyBuckets,
   fetchDailyCommandSurface,
   fetchDailyNotation,
@@ -92,6 +91,46 @@ function existingDays(): Set<string> {
       .filter((name) => name.endsWith('.json') && !name.endsWith('.partial'))
       .map((name) => name.slice(0, -'.json'.length)),
   );
+}
+
+function tallyOf(value: unknown): Record<string, number> {
+  if (value == null || typeof value !== 'object') return {};
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, n]) => [key, Number(n) || 0]),
+  );
+}
+
+/**
+ * Every frozen day on disk, oldest first. The only history that outlives the
+ * 92-day retention window, so a reader that wants more than the live window has
+ * to come through here.
+ *
+ * ! Numbers are coerced rather than trusted. These files are edited by hand and
+ *   survive across versions, and a string reaching a renderer would be formatted
+ *   and emitted as-is instead of being measured.
+ */
+export function readSnapshots(): DaySnapshot[] {
+  return [...existingDays()].sort().map((day) => {
+    const raw = JSON.parse(
+      readFileSync(`${SNAPSHOT_DIR}/${day}.json`, 'utf8'),
+    ) as Partial<DaySnapshot>;
+
+    return {
+      day,
+      capturedAt: String(raw.capturedAt ?? ''),
+      points: Number(raw.points) || 0,
+      rolls: Number(raw.rolls) || 0,
+      observedUsers: Number(raw.observedUsers) || 0,
+      commands: tallyOf(raw.commands),
+      surfaces: tallyOf(raw.surfaces),
+      buckets: tallyOf(raw.buckets),
+      notation: (Array.isArray(raw.notation) ? raw.notation : []).map((entry) => ({
+        term: String(entry?.term ?? ''),
+        modifiers: String(entry?.modifiers ?? ''),
+        n: Number(entry?.n) || 0,
+      })),
+    };
+  });
 }
 
 export interface SnapshotOutcome {

--- a/test/analytics/charts.test.ts
+++ b/test/analytics/charts.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  barChart,
+  compact,
+  esc,
+  lineChart,
+  niceMax,
+  percent,
+  type SeriesPoint,
+  stackedBar,
+  trendIsReadable,
+} from '../../scripts/analytics/charts';
+
+describe('esc', () => {
+  test('neutralizes the characters that would break out of markup', () => {
+    expect(esc('<script>"a" & \'b\'</script>')).toBe(
+      "&lt;script&gt;&quot;a&quot; &amp; 'b'&lt;/script&gt;",
+    );
+  });
+
+  test('leaves dice notation alone', () => {
+    expect(esc('4d6kh3')).toBe('4d6kh3');
+  });
+});
+
+describe('compact', () => {
+  test('groups thousands below the abbreviation threshold', () => {
+    expect(compact(999)).toBe('999');
+    expect(compact(1500)).toBe('1,500');
+  });
+
+  test('abbreviates once the digits stop being readable', () => {
+    expect(compact(12_345)).toBe('12.3K');
+    expect(compact(2_000_000)).toBe('2.0M');
+  });
+});
+
+describe('percent', () => {
+  test('defaults to one decimal and rounds down to none on request', () => {
+    expect(percent(0.125)).toBe('12.5%');
+    expect(percent(0.125, 0)).toBe('13%');
+  });
+});
+
+describe('niceMax', () => {
+  test('rounds an axis top up to something readable', () => {
+    expect(niceMax(34)).toBe(40);
+    expect(niceMax(250)).toBe(300);
+  });
+
+  test('keeps the maximum even, so the mid gridline lands on a whole number', () => {
+    // A max of 7 would draw the mid line at 3.5 and label it 4
+    for (const value of [1, 3, 7, 34, 250, 1234]) {
+      expect(niceMax(value)).toBeGreaterThanOrEqual(value);
+      expect(niceMax(value) / 2).toBe(Math.round(niceMax(value) / 2));
+    }
+  });
+
+  test('never returns zero, which would collapse the scale', () => {
+    expect(niceMax(0)).toBe(1);
+    expect(niceMax(-5)).toBe(1);
+  });
+});
+
+describe('trendIsReadable', () => {
+  const point = (day: string): SeriesPoint => ({ day, value: 1, frozen: false });
+
+  test('withholds a line below three points', () => {
+    expect(trendIsReadable([])).toBe(false);
+    expect(trendIsReadable([point('2026-01-01'), point('2026-01-02')])).toBe(false);
+  });
+
+  test('allows a line once there is a shape to read', () => {
+    expect(trendIsReadable(['2026-01-01', '2026-01-02', '2026-01-03'].map(point))).toBe(true);
+  });
+});
+
+describe('barChart', () => {
+  test('says so rather than drawing an empty axis', () => {
+    expect(barChart([])).toContain('No rows');
+  });
+
+  test('drops a weak row to the de-emphasis gray and keeps the rest accented', () => {
+    const svg = barChart([
+      { label: 'strong', value: 10, display: '10', strong: true },
+      { label: 'weak', value: 5, display: '5', strong: false },
+    ]);
+
+    expect(svg).toContain('var(--series-1)');
+    expect(svg).toContain('var(--de-emphasis)');
+  });
+
+  test('gives every bar a title, so a value is reachable on hover as well as in text', () => {
+    expect(barChart([{ label: 'd20', value: 3, display: '3' }])).toContain('<title>d20: 3</title>');
+  });
+
+  test('escapes a label rather than letting it close the tag', () => {
+    const svg = barChart([{ label: '<b>', value: 1, display: '1' }]);
+    expect(svg).toContain('&lt;b&gt;');
+    expect(svg).not.toContain('<b>');
+  });
+
+  test('draws nothing for a zero, rather than a stub that misstates it', () => {
+    const svg = barChart([{ label: 'none', value: 0, display: '0' }]);
+    expect(svg).not.toContain('<path');
+  });
+
+  test('truncates a label too long for its column, keeping it inside the viewBox', () => {
+    const long = 'exploding d10 pool (L5R, Exalted)';
+    const svg = barChart([{ label: long, value: 1, display: '1' }], 60);
+    const rendered = /<text class="cat"[^>]*>([^<]*)</.exec(svg)?.[1] ?? '';
+
+    expect(rendered).not.toBe(long);
+    expect(rendered.endsWith('…')).toBe(true);
+    // The full text survives where it cannot collide
+    expect(svg).toContain(`<title>${long}: 1</title>`);
+  });
+});
+
+describe('stackedBar', () => {
+  const wide = { label: 'inline', value: 90, share: 0.9, color: 'a', labelClass: 'ink-light' };
+  const narrow = { label: 'group', value: 1, share: 0.01, color: 'b', labelClass: 'ink-dark' };
+
+  test('labels a segment inline only when the text fits', () => {
+    const svg = stackedBar([wide, narrow]);
+
+    expect(svg).toContain('>90%<');
+    expect(svg).not.toContain('>1%<');
+  });
+
+  test('keeps the unlabelled segment reachable through its title', () => {
+    expect(stackedBar([wide, narrow])).toContain('group: 1 (1.0%)');
+  });
+
+  test('carries the ink class chosen for each fill', () => {
+    expect(stackedBar([wide])).toContain('on-fill ink-light');
+  });
+
+  test('keeps every segment inside the viewBox when several are thinner than the gap', () => {
+    const tiny = (label: string, value: number) => ({
+      label,
+      value,
+      share: value / 1000,
+      color: 'c',
+      labelClass: 'ink-dark',
+    });
+    const svg = stackedBar([tiny('a', 1), tiny('b', 1), tiny('c', 1), tiny('d', 997)]);
+
+    const ends = [...svg.matchAll(/x="([\d.]+)" y="0" width="([\d.]+)"/g)].map(
+      ([, x, width]) => Number(x) + Number(width),
+    );
+
+    expect(ends.length).toBe(4);
+    expect(Math.max(...ends)).toBeLessThanOrEqual(640);
+  });
+});
+
+describe('lineChart', () => {
+  const points: SeriesPoint[] = [
+    { day: '2026-01-01', value: 10, frozen: true },
+    { day: '2026-01-02', value: 20, frozen: false },
+    { day: '2026-01-03', value: 15, frozen: false },
+  ];
+
+  test('draws one 2px line with an area wash beneath it', () => {
+    const svg = lineChart(points);
+
+    expect(svg).toContain('stroke-width="2"');
+    expect(svg).toContain('fill-opacity="0.1"');
+  });
+
+  test('marks a frozen day so a snapshot is distinguishable from a live estimate', () => {
+    expect(lineChart(points)).toContain('2026-01-01: 10 (frozen snapshot)');
+  });
+
+  test('labels both ends of the axis and neither point between', () => {
+    const svg = lineChart(points);
+
+    expect(svg).toContain('>2026-01-01<');
+    expect(svg).toContain('>2026-01-03<');
+    expect(svg).not.toContain('>2026-01-02<');
+  });
+
+  test('drops the end label below its point when the series peaks last', () => {
+    // Peaking on the final day pins the point to the top of the plot, where a
+    // label placed above it would sit outside the viewBox
+    const rising: SeriesPoint[] = [
+      { day: '2026-01-01', value: 10, frozen: false },
+      { day: '2026-01-02', value: 25, frozen: false },
+      { day: '2026-01-03', value: 40, frozen: false },
+    ];
+    const y = Number(/<text class="val"[^>]*y="([\d.]+)"/.exec(lineChart(rising))?.[1]);
+
+    expect(y).toBeGreaterThan(12);
+  });
+});


### PR DESCRIPTION
Adds `--format table | json | html` over the existing `Report` object. `--format html --out <path>` writes a self-contained page — inline styles, hand-written SVG, no library, no build step, no network access.

Contents: a hero figure, a KPI row, and cards for rolls per day, game-system signals, surface mix, die sizes, modifier adoption, notation shapes and users. Every chart carries the same precision tag as its table counterpart, and the caveats sit on the page rather than only in the terminal.

`readSnapshots` lets the page reach further back than the live retention window, which also makes this the first real consumer of the snapshot format.

Charts are withheld rather than faked where the data cannot carry them: a series shorter than three days renders as its table, a zero draws no bar, a cohort with no eligible users reads `n/a`, and the subtitle states how far the charts reach beyond the queried window.

Colours are the validated categorical slots 1-4, stepped for each surface. In-fill labels take their ink from the fill's luminance — white on the aqua and yellow slots measures under 3:1. Every chart ships a table twin, so no value is reachable by colour alone. Verified rendered in both light and dark.

Two correctness notes worth the reviewer's attention:

- Gaps in the roll series are filled with zeroes. Points are spaced by position, so an unfilled gap would draw a fortnight of silence as one step and read as a smooth trend.
- The surface chart folds its tail into a single segment rather than dropping it. There are six possible surfaces and four slots; cutting the remainder would rescale the survivors so every segment disagreed with its own label.

`.tmp/` is now gitignored — the README points generated reports there.

Closes #57