### PR TITLE
fix: correct Perception translation and split notation lines

### DIFF
--- a/src/locales/be.ts
+++ b/src/locales/be.ts
@@ -22,12 +22,13 @@ export const be: Messages = {
 <code>4d6min2</code> — падняць кожны кубік як мінімум да 2 (таксама max)
 <code>6d10&gt;=6f1</code> — падлік поспехаў, адзінкі адымаюцца як правалы
 <code>1d20+7 vs 15</code> — праверка супраць складанасці са ступенямі поспеху
-<code>4dF</code> — кубікі Fate, <code>d%</code> — працэнтны
+<code>4dF</code> — кубікі Fate
+<code>d%</code> — працэнтны кубік
 <code>2d6+floor(1d4/2)</code> — функцыі: floor, ceil, round, abs, min, max, sqrt, pow
 
 Кароткі запіс: <code>/roll 20</code> кідае d20, <code>/roll 2 10 -1</code> кідае 2d10-1.
 
-Назаві кідок, узяўшы назву ў двукоссі ў канцы: <code>/roll 2d20+1 "Уважлівасць"</code>.
+Назаві кідок, узяўшы назву ў двукоссі ў канцы: <code>/roll 2d20+1 "Успрыманне"</code>.
 
 Паспрабуй натацыю ў ${playground('пясочніцы')} або адкрый ${reference('поўны даведнік')}.`,
 
@@ -43,7 +44,13 @@ export const be: Messages = {
 
   description: `Натацыя кубікаў для настольных ролевых гульняў — у любым чаце.
 
-4d6kh3 для характарыстык, 2d20kh1+7 з перавагай, 1d20+12 vs 20 для праверкі ў Pathfinder, 7d10>=6f1 для пула Storyteller, {1d8!, 1d6!}kh1 для Savage Worlds, 4dF для Fate, d% для Call of Cthulhu.
+4d6kh3 для характарыстык
+2d20kh1+7 з перавагай
+1d20+12 vs 20 для праверкі ў Pathfinder
+7d10>=6f1 для пула Storyteller
+{1d8!, 1d6!}kh1 для Savage Worlds
+4dF для Fate
+d% для Call of Cthulhu
 
 /roll дае суму, /full — разбор па кубіках, /help — даведку па натацыі. Напішы @rollrobot у любым чаце, каб кінуць кубікі без дадавання бота.`,
 };

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -22,7 +22,8 @@ Inline: tippe @rollrobot [Notation] in jedem Chat, oder wähle einen Eintrag aus
 <code>4d6min2</code> — jeden Würfel auf mindestens 2 anheben (auch max)
 <code>6d10&gt;=6f1</code> — Erfolge zählen, 1er als Fehlschläge abziehen
 <code>1d20+7 vs 15</code> — Probe gegen einen SG mit Erfolgsgraden
-<code>4dF</code> — Fate-Würfel, <code>d%</code> — Prozentwürfel
+<code>4dF</code> — Fate-Würfel
+<code>d%</code> — Prozentwürfel
 <code>2d6+floor(1d4/2)</code> — Funktionen: floor, ceil, round, abs, min, max, sqrt, pow
 
 Kurzschreibweise: <code>/roll 20</code> würfelt d20, <code>/roll 2 10 -1</code> würfelt 2d10-1.
@@ -43,7 +44,13 @@ Probiere die Notation im ${playground('Playground')} aus, oder lies die ${refere
 
   description: `Würfelnotation für Pen-and-Paper-Rollenspiele, in jedem Chat.
 
-4d6kh3 für Attribute, 2d20kh1+7 mit Vorteil, 1d20+12 vs 20 für eine Pathfinder-Probe, 7d10>=6f1 für einen Storyteller-Pool, {1d8!, 1d6!}kh1 für Savage Worlds, 4dF für Fate, d% für Call of Cthulhu.
+4d6kh3 für Attribute
+2d20kh1+7 mit Vorteil
+1d20+12 vs 20 für eine Pathfinder-Probe
+7d10>=6f1 für einen Storyteller-Pool
+{1d8!, 1d6!}kh1 für Savage Worlds
+4dF für Fate
+d% für Call of Cthulhu
 
 /roll liefert die Summe, /full die Aufschlüsselung pro Würfel, /help die Notationsübersicht. Tippe @rollrobot in jedem Chat, um ohne Hinzufügen des Bots zu würfeln.`,
 };

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -22,7 +22,8 @@ Inline: type @rollrobot [notation] in any chat, or pick a preset from the list.
 <code>4d6min2</code> — clamp each die to at least 2 (also max)
 <code>6d10&gt;=6f1</code> — count successes, subtract 1s as failures
 <code>1d20+7 vs 15</code> — check against a DC with degrees of success
-<code>4dF</code> — Fate dice, <code>d%</code> — percentile
+<code>4dF</code> — Fate dice
+<code>d%</code> — percentile die
 <code>2d6+floor(1d4/2)</code> — functions: floor, ceil, round, abs, min, max, sqrt, pow
 
 Shorthand: <code>/roll 20</code> rolls d20, <code>/roll 2 10 -1</code> rolls 2d10-1.
@@ -43,7 +44,13 @@ Try notation live in the ${playground('playground')}, or read the full ${referen
 
   description: `Dice notation for tabletop RPGs, rolled in any chat.
 
-4d6kh3 for ability scores, 2d20kh1+7 with advantage, 1d20+12 vs 20 for a Pathfinder check, 7d10>=6f1 for a Storyteller pool, {1d8!, 1d6!}kh1 for Savage Worlds, 4dF for Fate, d% for Call of Cthulhu.
+4d6kh3 for ability scores
+2d20kh1+7 with advantage
+1d20+12 vs 20 for a Pathfinder check
+7d10>=6f1 for a Storyteller pool
+{1d8!, 1d6!}kh1 for Savage Worlds
+4dF for Fate
+d% for Call of Cthulhu
 
 /roll gives the total, /full a die-by-die breakdown, /help the notation guide. Type @rollrobot in any chat to roll without adding the bot.`,
 };

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -22,7 +22,8 @@ En línea: escribe @rollrobot [notación] en cualquier chat, o elige una opción
 <code>4d6min2</code> — pon un mínimo de 2 en cada dado (también max)
 <code>6d10&gt;=6f1</code> — cuenta éxitos, resta los unos como fallos
 <code>1d20+7 vs 15</code> — prueba contra una CD con grados de éxito
-<code>4dF</code> — dados Fate, <code>d%</code> — porcentual
+<code>4dF</code> — dados Fate
+<code>d%</code> — dado porcentual
 <code>2d6+floor(1d4/2)</code> — funciones: floor, ceil, round, abs, min, max, sqrt, pow
 
 Notación abreviada: <code>/roll 20</code> tira d20, <code>/roll 2 10 -1</code> tira 2d10-1.
@@ -43,7 +44,13 @@ Comprueba la notación en vivo en el ${playground('área de pruebas')}, o consul
 
   description: `Notación de dados de rol, tirada en cualquier chat.
 
-4d6kh3 para características, 2d20kh1+7 con ventaja, 1d20+12 vs 20 para una prueba de Pathfinder, 7d10>=6f1 para una reserva de Storyteller, {1d8!, 1d6!}kh1 para Savage Worlds, 4dF para Fate, d% para Call of Cthulhu.
+4d6kh3 para características
+2d20kh1+7 con ventaja
+1d20+12 vs 20 para una prueba de Pathfinder
+7d10>=6f1 para una reserva de Storyteller
+{1d8!, 1d6!}kh1 para Savage Worlds
+4dF para Fate
+d% para Call of Cthulhu
 
 /roll da el total, /full el desglose dado a dado, /help la guía de notación. Escribe @rollrobot en cualquier chat para tirar sin añadir el bot.`,
 };

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -28,7 +28,8 @@ Inline: @rollrobot را در هر گفت‌وگو همراه با نمادگذا
 <code>4d6min2</code> — حداقل مقدار هر تاس دو می‌شود، همچنین (max)
 <code>6d10&gt;=6f1</code> — شمارش موفقیت‌ها، یک‌ها به‌عنوان شکست کم می‌شوند
 <code>1d20+7 vs 15</code> — چک در برابر درجهٔ سختی، با درجات موفقیت
-<code>4dF</code> — تاس Fate، <code>d%</code> — تاس درصدی
+<code>4dF</code> — تاس Fate
+<code>d%</code> — تاس درصدی
 <code>2d6+floor(1d4/2)</code> — توابع: floor, ceil, round, abs, min, max, sqrt, pow
 
 <code>/roll 20</code> — کوتاه‌نویسی، همان d20
@@ -56,7 +57,8 @@ Inline: @rollrobot را در هر گفت‌وگو همراه با نمادگذا
 1d20+12 vs 20 برای چک در Pathfinder
 7d10>=6f1 برای مجموعهٔ تاس Storyteller
 {1d8!, 1d6!}kh1 برای Savage Worlds
-4dF برای Fate، d% برای Call of Cthulhu
+4dF برای Fate
+d% برای Call of Cthulhu
 
 /roll — مجموع را می‌دهد
 /full — جزئیات هر تاس

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -22,7 +22,8 @@ Inline: digite @rollrobot [notação] em qualquer conversa, ou escolha uma opç�
 <code>4d6min2</code> — fixa cada dado em pelo menos 2 (também max)
 <code>6d10&gt;=6f1</code> — conta sucessos, subtrai os 1s como falhas
 <code>1d20+7 vs 15</code> — teste contra uma CD com graus de sucesso
-<code>4dF</code> — dados Fate, <code>d%</code> — percentual
+<code>4dF</code> — dados Fate
+<code>d%</code> — dado percentual
 <code>2d6+floor(1d4/2)</code> — funções: floor, ceil, round, abs, min, max, sqrt, pow
 
 Notação abreviada: <code>/roll 20</code> rola d20, <code>/roll 2 10 -1</code> rola 2d10-1.
@@ -43,7 +44,13 @@ Teste a notação no ${playground('playground')}, ou leia a ${reference('referê
 
   description: `Notação de dados de RPG, rolada em qualquer conversa.
 
-4d6kh3 para atributos, 2d20kh1+7 com vantagem, 1d20+12 vs 20 para um teste de Pathfinder, 7d10>=6f1 para uma reserva de Storyteller, {1d8!, 1d6!}kh1 para Savage Worlds, 4dF para Fate, d% para Call of Cthulhu.
+4d6kh3 para atributos
+2d20kh1+7 com vantagem
+1d20+12 vs 20 para um teste de Pathfinder
+7d10>=6f1 para uma reserva de Storyteller
+{1d8!, 1d6!}kh1 para Savage Worlds
+4dF para Fate
+d% para Call of Cthulhu
 
 /roll dá o total, /full o detalhe dado a dado, /help o guia de notação. Digite @rollrobot em qualquer conversa para rolar sem adicionar o bot.`,
 };

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -22,12 +22,13 @@ export const ru: Messages = {
 <code>4d6min2</code> — поднять каждый кубик минимум до 2 (также max)
 <code>6d10&gt;=6f1</code> — подсчёт успехов, единицы вычитаются как провалы
 <code>1d20+7 vs 15</code> — проверка против сложности со степенями успеха
-<code>4dF</code> — кубики Fate, <code>d%</code> — процентный кубик
+<code>4dF</code> — кубики Fate
+<code>d%</code> — процентный кубик
 <code>2d6+floor(1d4/2)</code> — функции: floor, ceil, round, abs, min, max, sqrt, pow
 
 Короткая запись: <code>/roll 20</code> бросает d20, <code>/roll 2 10 -1</code> бросает 2d10-1.
 
-Назови бросок, взяв название в кавычки в конце: <code>/roll 2d20+1 "Внимательность"</code>.
+Назови бросок, взяв название в кавычки в конце: <code>/roll 2d20+1 "Восприятие"</code>.
 
 Попробуй нотацию в ${playground('песочнице')} или открой ${reference('полный справочник по нотации')}.`,
 
@@ -43,7 +44,13 @@ export const ru: Messages = {
 
   description: `Нотация кубиков для настольных ролевых игр — в любом чате.
 
-4d6kh3 для характеристик, 2d20kh1+7 с преимуществом, 1d20+12 vs 20 для проверки в Pathfinder, 7d10>=6f1 для пула Storyteller, {1d8!, 1d6!}kh1 для Savage Worlds, 4dF для Fate, d% для Call of Cthulhu.
+4d6kh3 для характеристик
+2d20kh1+7 с преимуществом
+1d20+12 vs 20 для проверки в Pathfinder
+7d10>=6f1 для пула Storyteller
+{1d8!, 1d6!}kh1 для Savage Worlds
+4dF для Fate
+d% для Call of Cthulhu
 
 /roll даёт сумму, /full — разбор по кубикам, /help — справку по нотации. Напиши @rollrobot в любом чате, чтобы бросить кубики без добавления бота.`,
 };

--- a/src/locales/uk.ts
+++ b/src/locales/uk.ts
@@ -22,12 +22,13 @@ export const uk: Messages = {
 <code>4d6min2</code> — підняти кожен кубик щонайменше до 2 (також max)
 <code>6d10&gt;=6f1</code> — підрахунок успіхів, одиниці віднімаються як провали
 <code>1d20+7 vs 15</code> — перевірка проти складності зі ступенями успіху
-<code>4dF</code> — кубики Fate, <code>d%</code> — відсотковий
+<code>4dF</code> — кубики Fate
+<code>d%</code> — відсотковий кубик
 <code>2d6+floor(1d4/2)</code> — функції: floor, ceil, round, abs, min, max, sqrt, pow
 
 Коротка форма: <code>/roll 20</code> кидає d20, <code>/roll 2 10 -1</code> кидає 2d10-1.
 
-Назви кидок, взявши назву в лапки в кінці: <code>/roll 2d20+1 "Уважність"</code>.
+Назви кидок, взявши назву в лапки в кінці: <code>/roll 2d20+1 "Увага"</code>.
 
 Спробуй нотацію наживо в ${playground('пісочниці')} або відкрий ${reference('повний довідник')}.`,
 
@@ -43,7 +44,13 @@ export const uk: Messages = {
 
   description: `Нотація кубиків для настільних рольових ігор — у будь-якому чаті.
 
-4d6kh3 для характеристик, 2d20kh1+7 з перевагою, 1d20+12 vs 20 для перевірки в Pathfinder, 7d10>=6f1 для пулу Storyteller, {1d8!, 1d6!}kh1 для Savage Worlds, 4dF для Fate, d% для Call of Cthulhu.
+4d6kh3 для характеристик
+2d20kh1+7 з перевагою
+1d20+12 vs 20 для перевірки в Pathfinder
+7d10>=6f1 для пулу Storyteller
+{1d8!, 1d6!}kh1 для Savage Worlds
+4dF для Fate
+d% для Call of Cthulhu
 
 /roll дає суму, /full — розбір по кубиках, /help — довідку з нотації. Напиши @rollrobot у будь-якому чаті, щоб кинути кубики без додавання бота.`,
 };


### PR DESCRIPTION
Corrected the Perception example label in the Slavic locales and reflowed the Fate/percentile notation lines.

- `ru`: `Внимательность` → `Восприятие` — the official Hobby World Player's Handbook (2019) and the dnd.su style guide both use `Восприятие`; `Внимательность` came from the superseded Студия Фантом fan translation
- `uk`: `Уважність` → `Увага`, per the Ukrainian community SRD
- `be`: `Уважлівасць` → `Успрыманне`
- `4dF` and `d%` split onto separate lines in the help notation block, all 8 locales
- Restored the noun stranded by that split in `en`, `be`, `uk`, `es`, `pt` — the old single line only worked because "dice" carried over from the Fate half
- `description` reflowed to one example per line, all 8 locales; net shorter than the prose it replaces, worst case `de` at 418/512

`uk` and `be` were calques of the Russian term rather than translations from `en`, which is how one stale term reached three locales.

`description` and `shortDescription` are pushed to Telegram by `scripts/configure-telegram.ts`, so those changes are inert until that script runs. The `help` changes go live on deploy.