### PR TITLE
fix: log the full roll request with its label

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "rollrobot",
       "dependencies": {
         "grammy": "^1.45.1",
-        "roll-parser": "3.2.0",
+        "roll-parser": "3.2.1",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.7",
@@ -253,7 +253,7 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "roll-parser": ["roll-parser@3.2.0", "", { "bin": { "roll-parser": "dist/cli/index.js" } }, "sha512-fSYv4LZYQ152SyXHqLMeIQbmonnF3HD4ZXGc+N8z6cefLVJhmNj3zOy04AsTgV3w4AG8blZRS6vcckgLD2zBLA=="],
+    "roll-parser": ["roll-parser@3.2.1", "", { "bin": { "roll-parser": "dist/cli/index.js" } }, "sha512-cRRHAl4izfdeb+Tl7n3f5KQiQA5Ellvlx1tRCWNzeK39LKukzlwgOE7juuZP4MdxIZn+wHYeum7wk+2aPjO7FA=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "grammy": "^1.45.1",
-    "roll-parser": "3.2.0"
+    "roll-parser": "3.2.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.7",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -23,7 +23,12 @@ function senderName(ctx: Context): string {
   return ctx.from?.username ? `@${ctx.from.username}` : (ctx.from?.first_name ?? 'unknown');
 }
 
-function logRoll(ctx: Context, command: string, notation: string, reply: string): void {
+/** Echoes the request as typed: normalized notation followed by its quoted label, if any. */
+function formatRequest(notation: string, label: string | null): string {
+  return label == null ? notation : `${notation} "${label}"`.trim();
+}
+
+function logRoll(ctx: Context, command: string, request: string, reply: string): void {
   const name = senderName(ctx);
   const group = ctx.chat?.title ? ` [${ctx.chat.title}]` : '';
   const result = reply
@@ -32,7 +37,7 @@ function logRoll(ctx: Context, command: string, notation: string, reply: string)
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&amp;/g, '&');
-  console.log(`${name}${group} /${command}: ${notation} | ${result}`);
+  console.log(`${name}${group} /${command} ${request} | ${result}`);
 }
 
 /** Result IDs are `<variant>:<uuid>`; unprefixed IDs predate that and cannot be attributed. */
@@ -120,7 +125,7 @@ export function createBot(env: BotEnv): Bot {
     const { notation: rest, label } = extractLabel((ctx.match as string) ?? '');
     const notation = normalizeNotation(rest);
     const { text, result } = rollReply(notation, label);
-    logRoll(ctx, 'roll', notation, text);
+    logRoll(ctx, 'roll', formatRequest(notation, label), text);
     await ctx.reply(text, replyOptions(ctx));
     await trackRoll(env, trackContext(ctx, 'roll'), result);
   });
@@ -129,7 +134,7 @@ export function createBot(env: BotEnv): Bot {
     const { notation: rest, label } = extractLabel((ctx.match as string) ?? '');
     const notation = normalizeNotation(rest);
     const { text, result } = fullReply(notation, label);
-    logRoll(ctx, 'full', notation, text);
+    logRoll(ctx, 'full', formatRequest(notation, label), text);
     await ctx.reply(text, replyOptions(ctx));
     await trackRoll(env, trackContext(ctx, 'full'), result);
   });
@@ -137,7 +142,7 @@ export function createBot(env: BotEnv): Bot {
   bot.command('random', async (ctx) => {
     const { label } = extractLabel((ctx.match as string) ?? '');
     const { text, result } = randomReply(label);
-    logRoll(ctx, 'random', RANDOM_NOTATION, text);
+    logRoll(ctx, 'random', formatRequest(RANDOM_NOTATION, label), text);
     await ctx.reply(text, replyOptions(ctx));
     await trackRoll(env, trackContext(ctx, 'random'), result);
   });
@@ -147,8 +152,9 @@ export function createBot(env: BotEnv): Bot {
     const name = senderName(ctx);
     const { query, result_id } = ctx.chosenInlineResult;
     const variant = inlineVariant(result_id);
-    const notation = variant === 'random' ? RANDOM_NOTATION : query || DEFAULT_NOTATION;
-    console.log(`${name} [inline] ${variant}: ${notation}`);
+    const { notation: queried, label } = extractLabel(query);
+    const notation = variant === 'random' ? RANDOM_NOTATION : queried || DEFAULT_NOTATION;
+    console.log(`${name} [inline] ${variant} ${formatRequest(notation, label)}`);
 
     const context = { command: 'inline', surface: 'inline', userId: ctx.from?.id } as const;
     await trackRoll(env, context, () => chosenInlineRoll(query, variant));

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -64,17 +64,64 @@ describe('Chosen inline results', () => {
   }
 
   test('should log the chosen variant', async () => {
-    expect(await chosenLog('roll:abc', 'd20')).toEqual('@testuser [inline] roll: d20');
-    expect(await chosenLog('full:abc', 'd20')).toEqual('@testuser [inline] full: d20');
-    expect(await chosenLog('random:abc')).toEqual('@testuser [inline] random: d100');
+    expect(await chosenLog('roll:abc', 'd20')).toEqual('@testuser [inline] roll d20');
+    expect(await chosenLog('full:abc', 'd20')).toEqual('@testuser [inline] full d20');
+    expect(await chosenLog('random:abc')).toEqual('@testuser [inline] random d100');
   });
 
   test('should log the default notation for an empty query', async () => {
-    expect(await chosenLog('roll:abc')).toEqual('@testuser [inline] roll: d20');
+    expect(await chosenLog('roll:abc')).toEqual('@testuser [inline] roll d20');
   });
 
   test('should log an unknown variant for unprefixed ids', async () => {
-    expect(await chosenLog('abc', 'd20')).toEqual('@testuser [inline] unknown: d20');
+    expect(await chosenLog('abc', 'd20')).toEqual('@testuser [inline] unknown d20');
+  });
+
+  test('should log the label of a queried roll', async () => {
+    expect(await chosenLog('roll:abc', '2d20+1 "Perception"')).toEqual(
+      '@testuser [inline] roll 2d20+1 "Perception"',
+    );
+    expect(await chosenLog('full:abc', '«Атака»')).toEqual('@testuser [inline] full d20 "Атака"');
+    expect(await chosenLog('random:abc', '"Fate"')).toEqual(
+      '@testuser [inline] random d100 "Fate"',
+    );
+  });
+});
+
+describe('Command logging', () => {
+  let log: ReturnType<typeof spyOn<Console, 'log'>>;
+
+  beforeEach(() => {
+    log = spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    log.mockRestore();
+  });
+
+  async function commandLog(text: string, chatType = 'private'): Promise<string> {
+    await bot.send(text, chatType);
+    return log.mock.calls.at(-1)?.[0] ?? '';
+  }
+
+  test('should log the request as typed', async () => {
+    expect(await commandLog('/roll 2d20+1')).toMatch(
+      /^@testuser \/roll 2d20\+1 \| 2d20 \+ 1 = \d+$/,
+    );
+    expect(await commandLog('/full 2d6')).toMatch(/^@testuser \/full 2d6 \| /);
+    expect(await commandLog('/random')).toMatch(/^@testuser \/random d100 \| \d+$/);
+  });
+
+  test('should quote the label after the notation', async () => {
+    expect(await commandLog('/roll 2d20+1 "Perception"')).toMatch(
+      /^@testuser \/roll 2d20\+1 "Perception" \| Perception 2d20 \+ 1 = \d+$/,
+    );
+    expect(await commandLog('/random «Судьба»')).toMatch(/^@testuser \/random d100 "Судьба" \| /);
+  });
+
+  test('should log the normalized notation of shorthand and empty input', async () => {
+    expect(await commandLog('/roll')).toMatch(/^@testuser \/roll d20 \| /);
+    expect(await commandLog('/roll 2 10 -1')).toMatch(/^@testuser \/roll 2d10-1 \| /);
   });
 });
 


### PR DESCRIPTION
Roll logs no longer put a colon after the command name, and they now echo the quoted label when the request has one: `@edloidas /roll 2d20+1 "Perception" | Perception 2d20 + 1 = 21`. Chosen inline results use the same format, so labels are preserved there too.

The echoed notation stays the normalized one (`/roll` logs `d20`, `/random` logs `d100`), and labels are printed with plain `"` quotes.

Also bumps `roll-parser` from `3.2.0` to `3.2.1` in a separate commit.