### PR TITLE
fix: show the rolled notation for random rolls #63

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -188,11 +188,6 @@ export function formatResult(result: RollResult): string {
   return `<code>${escapeHtml(result.expression)}</code> = ${formatOutcome(result)}`;
 }
 
-/** Bare reply: the total alone, for rolls where the notation is implied by the command. */
-export function formatTotal(result: RollResult): string {
-  return `<b>${result.total}</b>`;
-}
-
 /** Puts the roll's name above it as a quote. Passing no label leaves the reply untouched. */
 export function withLabel(reply: string, label?: string | null): string {
   return label ? `<blockquote>${escapeHtml(label)}</blockquote>\n${reply}` : reply;

--- a/src/handlers/inline.ts
+++ b/src/handlers/inline.ts
@@ -1,6 +1,6 @@
 import type { InlineQueryResult } from 'grammy/types';
 import { isNotationError, roll, type RollResult } from 'roll-parser';
-import { formatDetailedResult, formatResult, formatTotal, withLabel } from '../format';
+import { formatDetailedResult, formatResult, withLabel } from '../format';
 import { DEFAULT_LOCALE, type Locale, type Messages, messages } from '../i18n';
 import { extractLabel } from '../label';
 import { ROLL_LIMITS } from '../limits';
@@ -69,7 +69,7 @@ function createQueryArticles(
 function createPresetArticles(titles: Messages['inline']): InlineQueryResult[] {
   return [
     ...createVariantArticles(roll(DEFAULT_NOTATION), DEFAULT_NOTATION, titles),
-    createArticle('random', titles.random, RANDOM_NOTATION, formatTotal(roll(RANDOM_NOTATION))),
+    createArticle('random', titles.random, RANDOM_NOTATION, formatResult(roll(RANDOM_NOTATION))),
   ];
 }
 

--- a/src/handlers/random.ts
+++ b/src/handlers/random.ts
@@ -1,10 +1,10 @@
 import { roll } from 'roll-parser';
-import { formatTotal, withLabel } from '../format';
+import { formatResult, withLabel } from '../format';
 import type { Reply } from './reply';
 
 export const RANDOM_NOTATION = 'd100';
 
 export function randomReply(label?: string | null): Reply {
   const result = roll(RANDOM_NOTATION);
-  return { text: withLabel(formatTotal(result), label), result };
+  return { text: withLabel(formatResult(result), label), result };
 }

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -43,7 +43,7 @@ describe('Bot message options', () => {
     const pattern = /^<code>1d20<\/code> = <b>\d+<\/b>/;
     expect(await bot.send('/roll@testbot d20')).toMatch(pattern);
     expect(await bot.send('/full@testbot d20')).toMatch(pattern);
-    expect(await bot.send('/random@testbot')).toMatch(/^<b>\d{1,3}<\/b>$/);
+    expect(await bot.send('/random@testbot')).toMatch(/^<code>1d100<\/code> = <b>\d{1,3}<\/b>$/);
   });
 });
 
@@ -109,7 +109,7 @@ describe('Command logging', () => {
       /^@testuser \/roll 2d20\+1 \| 2d20 \+ 1 = \d+$/,
     );
     expect(await commandLog('/full 2d6')).toMatch(/^@testuser \/full 2d6 \| /);
-    expect(await commandLog('/random')).toMatch(/^@testuser \/random d100 \| \d+$/);
+    expect(await commandLog('/random')).toMatch(/^@testuser \/random d100 \| 1d100 = \d+$/);
   });
 
   test('should quote the label after the notation', async () => {

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,13 +1,7 @@
 import { describe, test, expect } from 'bun:test';
 import { isRollParserError, roll, type RollParserError } from 'roll-parser';
 import { createMockRng } from 'roll-parser/testing';
-import {
-  escapeHtml,
-  formatDetailedResult,
-  formatError,
-  formatResult,
-  formatTotal,
-} from '../src/format';
+import { escapeHtml, formatDetailedResult, formatError, formatResult } from '../src/format';
 
 function rollError(notation: string): RollParserError {
   try {
@@ -237,13 +231,6 @@ describe('formatDetailedResult', () => {
   test('marks dice in sorted order', () => {
     const result = roll('4d6s', { rng: createMockRng([3, 6, 1, 5]) });
     expect(formatDetailedResult(result)).toBe('<code>4d6s</code> = <b>15</b>\n[1↓, 3, 5, 6↑]');
-  });
-});
-
-describe('formatTotal', () => {
-  test('shows the total alone', () => {
-    const result = roll('d100', { rng: createMockRng([48]) });
-    expect(formatTotal(result)).toBe('<b>48</b>');
   });
 });
 

--- a/test/handlers/inline.test.ts
+++ b/test/handlers/inline.test.ts
@@ -90,9 +90,11 @@ describe('Inline queries', () => {
     }
   });
 
-  test('should reply with the total alone for the random preset', async () => {
+  test('should reply with the d100 notation and total for the random preset', async () => {
     const results = await bot.sendInline('');
-    expect(results[2].input_message_content.message_text).toMatch(/^<b>\d{1,3}<\/b>$/);
+    expect(results[2].input_message_content.message_text).toMatch(
+      /^<code>1d100<\/code> = <b>\d{1,3}<\/b>$/,
+    );
   });
 
   test('should localize titles for the requesting user', async () => {

--- a/test/handlers/random.test.ts
+++ b/test/handlers/random.test.ts
@@ -7,10 +7,10 @@ beforeEach(() => {
   bot = new TestBot();
 });
 
-const pattern = /^<b>\d{1,3}<\/b>$/;
+const pattern = /^<code>1d100<\/code> = <b>\d{1,3}<\/b>$/;
 
 describe('/random', () => {
-  test('should reply with the d100 total alone', async () => {
+  test('should reply with the d100 notation and total', async () => {
     expect(await bot.send('/random')).toMatch(pattern);
   });
 
@@ -18,16 +18,16 @@ describe('/random', () => {
     expect(await bot.send('/random d100+1000')).toMatch(pattern);
   });
 
-  test('should quote the label above the total', async () => {
+  test('should quote the label above the roll', async () => {
     expect(await bot.send('/random "Is this a good bot?"')).toMatch(
-      /^<blockquote>Is this a good bot\?<\/blockquote>\n<b>\d{1,3}<\/b>$/,
+      /^<blockquote>Is this a good bot\?<\/blockquote>\n<code>1d100<\/code> = <b>\d{1,3}<\/b>$/,
     );
   });
 
   // The notation half stays ignored, as it is without a label
   test('should keep the label when arguments precede it', async () => {
     expect(await bot.send('/random d6 "note"')).toMatch(
-      /^<blockquote>note<\/blockquote>\n<b>\d{1,3}<\/b>$/,
+      /^<blockquote>note<\/blockquote>\n<code>1d100<\/code> = <b>\d{1,3}<\/b>$/,
     );
   });
 });


### PR DESCRIPTION
Random rolls now render as `1d100 = <total>` instead of the bare total, so the sent message says what was rolled. Applies to the inline `Random` preset and the `/random` command reply.

- Replaced `formatTotal` with `formatResult` in `src/handlers/random.ts` and the inline random article
- Removed `formatTotal` from `src/format.ts` — no callers left
- Updated random, inline, and bot log tests to the new shape

Closes #63
