### PR TITLE
feat: add /ask yes-no command #65

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -1,7 +1,9 @@
 # Analytics
 
 Every roll is recorded to the `rollrobot_events` Analytics Engine dataset — one data point
-per *distinct* dice term, capped at 20 per roll, plus one per `/start` and `/help`. Repeated
+per *distinct* dice term, capped at 20 per roll, plus one per `/start`, `/help` and `/ask`.
+An answer records no dice term — the `d2` behind it is an implementation detail, not a roll
+anyone asked for. Repeated
 shapes collapse, so `2d6+2d6` records a single `2d6`. Nothing identifying is stored: the
 Telegram user ID is written as an HMAC-SHA256 digest keyed by `ANALYTICS_SALT`, and the
 dataset is write-only from the Worker.

--- a/README.md
+++ b/README.md
@@ -42,14 +42,21 @@ Fate, `d%` for Call of Cthulhu.
 | `/roll [notation]` | `/r` | The normalized expression and its total |
 | `/full [notation]` | `/f` | The same, plus a die-by-die breakdown |
 | `/random` | | A `d100` roll, total only |
+| `/ask [question]` | `/a` | The question quoted, and `Yes` or `No` under it |
 | `/help` | | Notation guide and links |
 
 Omitting the notation rolls `d20`. In groups the bot replies to the message it was called
 from, so several people can roll at once without the thread coming apart.
 
+`/ask` takes the whole line as its question, so it never fails to parse — quotes, notation and
+punctuation are all part of the question rather than syntax. The answer stays English in every
+language: the sender's interface language is a poor guess at the language of the chat.
+
 Typing `@rollrobot [notation]` in any chat offers one roll under two headings, **Roll** and
 **Full** — the choice is about display, not a reroll. With no notation the list falls back to
-`d20` and `d100` presets. Results are personal and uncached, so every new query rolls afresh.
+`d20` and `d100` presets. Anything that is not notation for a named die also offers **Ask**,
+leading the list when the query does not roll and trailing it when it does. Results are
+personal and uncached, so every new query rolls afresh.
 
 ## Notation
 

--- a/src/analytics/track.ts
+++ b/src/analytics/track.ts
@@ -21,7 +21,7 @@ export interface AnalyticsEnv {
   ANALYTICS_SALT?: string;
 }
 
-export type Command = 'roll' | 'full' | 'random' | 'inline' | 'help' | 'start';
+export type Command = 'roll' | 'full' | 'random' | 'ask' | 'inline' | 'help' | 'start';
 
 export type Surface = 'private' | 'group' | 'supergroup' | 'channel' | 'inline' | 'unknown';
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -8,6 +8,7 @@ import {
   trackRoll,
 } from './analytics/track';
 import { rollReply } from './handlers/roll';
+import { askReply } from './handlers/ask';
 import { fullReply } from './handlers/full';
 import { RANDOM_NOTATION, randomReply } from './handlers/random';
 import { helpReply } from './handlers/help';
@@ -28,16 +29,22 @@ function formatRequest(notation: string, label: string | null): string {
   return label == null ? notation : `${notation} "${label}"`.trim();
 }
 
+// ! User text reaches the log verbatim, and a newline in it would forge a second entry that
+//   reads like a genuine one — reachable through a question and through a roll's label alike.
+function oneLine(text: string): string {
+  return text.replace(/\s*\n\s*/g, ' ');
+}
+
 function logRoll(ctx: Context, command: string, request: string, reply: string): void {
   const name = senderName(ctx);
   const group = ctx.chat?.title ? ` [${ctx.chat.title}]` : '';
-  const result = reply
-    .replace(/\n/g, ' ')
+  const result = oneLine(reply)
     .replace(/<[^>]+>/g, '')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&amp;/g, '&');
-  console.log(`${name}${group} /${command} ${request} | ${result}`);
+  const parts = [`${name}${group}`, `/${command}`, oneLine(request), '|', result];
+  console.log(parts.filter((part) => part !== '').join(' '));
 }
 
 /** Result IDs are `<variant>:<uuid>`; unprefixed IDs predate that and cannot be attributed. */
@@ -139,6 +146,13 @@ export function createBot(env: BotEnv): Bot {
     await trackRoll(env, trackContext(ctx, 'full'), result);
   });
 
+  bot.command(['ask', 'a'], async (ctx) => {
+    const { text, question } = askReply((ctx.match as string) ?? '');
+    logRoll(ctx, 'ask', question ?? '', text);
+    await ctx.reply(text, replyOptions(ctx));
+    await trackCommand(env, trackContext(ctx, 'ask'));
+  });
+
   bot.command('random', async (ctx) => {
     const { label } = extractLabel((ctx.match as string) ?? '');
     const { text, result } = randomReply(label);
@@ -152,6 +166,15 @@ export function createBot(env: BotEnv): Bot {
     const name = senderName(ctx);
     const { query, result_id } = ctx.chosenInlineResult;
     const variant = inlineVariant(result_id);
+
+    // An answer has no dice shape to record, and the roll path's `?? roll(DEFAULT_NOTATION)`
+    // fallback would invent a phantom d20 term for it
+    if (variant === 'ask') {
+      console.log(`${name} [inline] ask ${oneLine(query)}`);
+      await trackCommand(env, { command: 'ask', surface: 'inline', userId: ctx.from?.id });
+      return;
+    }
+
     const { notation: queried, label } = extractLabel(query);
     const notation = variant === 'random' ? RANDOM_NOTATION : queried || DEFAULT_NOTATION;
     console.log(`${name} [inline] ${variant} ${formatRequest(notation, label)}`);

--- a/src/handlers/ask.ts
+++ b/src/handlers/ask.ts
@@ -1,0 +1,38 @@
+import { roll } from 'roll-parser';
+import { withLabel } from '../format';
+import { capText } from '../label';
+
+/** The coin behind an answer, so randomness has one source across the bot. */
+const ASK_NOTATION = 'd2';
+
+const YES = '<b>Yes</b> ✅';
+const NO = '<b>No</b> ❌';
+
+// ! The question is echoed back inside the reply and nothing else on this path caps it —
+//   `extractLabel` never runs, so its own cap is out of reach. Escaping expands a character
+//   sixfold at worst (a bidi control becomes `U+200F`), which leaves 300 code points an order
+//   of magnitude clear of Telegram's 4096 limit.
+const MAX_QUESTION_LENGTH = 300;
+
+export interface Answer {
+  text: string;
+  /** The question as it appears in the reply — trimmed and capped — or `null` when none was asked. */
+  question: string | null;
+}
+
+/**
+ * Answers Yes or No, quoting the question above it.
+ *
+ * The answer stays English in every locale. Telegram reports the sender's interface
+ * language, which is a poor guess at the language of the chat they are writing in — a
+ * Russian-configured client asking a question in an English group would get `Да`.
+ *
+ * grammY only trims the leading side of a command's argument, so the trailing side is
+ * trimmed here — otherwise `/ask Rain?⏎⏎` leaves blank lines inside the quote.
+ */
+export function askReply(question?: string | null): Answer {
+  const asked = question?.trim();
+  const capped = asked ? capText(asked, MAX_QUESTION_LENGTH) : null;
+  const answer = roll(ASK_NOTATION).total === 1 ? YES : NO;
+  return { text: withLabel(answer, capped), question: capped };
+}

--- a/src/handlers/inline.ts
+++ b/src/handlers/inline.ts
@@ -5,6 +5,7 @@ import { DEFAULT_LOCALE, type Locale, type Messages, messages } from '../i18n';
 import { extractLabel } from '../label';
 import { ROLL_LIMITS } from '../limits';
 import { normalizeNotation } from '../notation';
+import { askReply } from './ask';
 import { RANDOM_NOTATION } from './random';
 
 function createInputMessageContent(text: string) {
@@ -15,7 +16,7 @@ function createInputMessageContent(text: string) {
   };
 }
 
-type InlineVariant = 'roll' | 'full' | 'random';
+type InlineVariant = 'roll' | 'full' | 'random' | 'ask';
 
 function createArticle(
   variant: InlineVariant,
@@ -108,23 +109,63 @@ export function chosenInlineRoll(query: string, variant: string): RollResult {
   return resolveQueryRoll(query)?.result ?? roll(DEFAULT_NOTATION);
 }
 
+/** Names a die outright — `2d6`, `d%`, `4dF` — as opposed to the bare-number shorthand. */
+const EXPLICIT_DIE = /d/i;
+
+/**
+ * Whether the query reads as a question rather than a roll, and so earns an `Ask` article.
+ *
+ * The die-marker test is deliberately gated behind a successful parse: `Should I text her?`
+ * carries a `d` in "Should" and has to stay a question. Shorthand notation is left as a
+ * question too — `2024` and `1 2` roll `d2024` and `1d2`, but neither is a die anyone named.
+ *
+ * ! A quoted question is why the parse alone cannot decide this. `"Should I text her?"`, and
+ *   the `“…”` / `«…»` pairs mobile keyboards substitute, parse today as a `d20` labelled with
+ *   the question — so hiding `Ask` whenever a roll parsed would hide it exactly where a
+ *   question is likeliest.
+ */
+function isQuestion(query: string, resolved: QueryRoll | null, notation: string): boolean {
+  const asked = query.trim();
+  // Nothing, or a lone `d`, is notation being typed rather than a question — the two cases
+  // `resolveQueryRoll` also declines to roll on
+  if (asked === '' || asked === 'd') return false;
+  return resolved == null || !EXPLICIT_DIE.test(notation);
+}
+
+/** Trailing when the query rolled on notation of its own; there the question is the aside. */
+function isAskTrailing(resolved: QueryRoll | null, notation: string): boolean {
+  return resolved != null && notation !== '' && notation !== 'd';
+}
+
 export function createInlineArticles(
   query = '',
   locale: Locale = DEFAULT_LOCALE,
 ): InlineQueryResponse {
   const titles = messages(locale).inline;
+  const { notation } = extractLabel(query);
   const resolved = resolveQueryRoll(query);
 
-  if (resolved != null) {
-    return {
-      results: createQueryArticles(resolved.result, titles, resolved.label),
-      hasInvalidQuery: false,
-    };
-  }
+  const rolls =
+    resolved != null
+      ? createQueryArticles(resolved.result, titles, resolved.label)
+      : createPresetArticles(titles);
 
-  const { notation } = extractLabel(query);
+  const ask = isQuestion(query, resolved, notation)
+    ? createArticle('ask', titles.ask, titles.answer, askReply(query).text)
+    : null;
+
   return {
-    results: createPresetArticles(titles),
-    hasInvalidQuery: notation !== '' && notation !== 'd',
+    results: ask == null ? rolls : askArticles(rolls, ask, resolved, notation),
+    // ! Left on the parse alone, so a question still raises the help button
+    hasInvalidQuery: resolved == null && notation !== '' && notation !== 'd',
   };
+}
+
+function askArticles(
+  rolls: InlineQueryResult[],
+  ask: InlineQueryResult,
+  resolved: QueryRoll | null,
+  notation: string,
+): InlineQueryResult[] {
+  return isAskTrailing(resolved, notation) ? [...rolls, ask] : [ask, ...rolls];
 }

--- a/src/label.ts
+++ b/src/label.ts
@@ -29,10 +29,16 @@ const MAX_LABEL_LENGTH = 100;
 
 const ELLIPSIS = '…';
 
+/** Truncates to `max` code points, the last of them an ellipsis. Counted in code points so a
+ * cap on escaped output holds: escaping expands per character, not per UTF-16 unit. */
+export function capText(text: string, max: number): string {
+  const points = [...text];
+  if (points.length <= max) return text;
+  return points.slice(0, max - 1).join('') + ELLIPSIS;
+}
+
 function capLabel(label: string): string {
-  const points = [...label];
-  if (points.length <= MAX_LABEL_LENGTH) return label;
-  return points.slice(0, MAX_LABEL_LENGTH - 1).join('') + ELLIPSIS;
+  return capText(label, MAX_LABEL_LENGTH);
 }
 
 export interface LabelledInput {

--- a/src/locales/be.ts
+++ b/src/locales/be.ts
@@ -2,7 +2,14 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const be: Messages = {
-  inline: { roll: 'Кідок', full: 'Падрабязны', random: 'Выпадковы', help: 'Як карыстацца' },
+  inline: {
+    roll: 'Кідок',
+    full: 'Падрабязны',
+    random: 'Выпадковы',
+    ask: 'Пытанне',
+    answer: 'Адказвае Yes або No',
+    help: 'Як карыстацца',
+  },
 
   help: `Кідай кубікі як ніхто іншы — поўная ролевая натацыя: захаванне/скід, выбуховыя кубікі, перакіды, пулы поспехаў і праверкі.
 
@@ -10,6 +17,7 @@ export const be: Messages = {
 /roll [натацыя] — кідок і сума (скарот: /r)
 /full [натацыя] — кідок з разборам па кубіках (скарот: /f)
 /random — кідок d100 (<code>d%</code>)
+/ask [пытанне] — адказ Yes або No (скарот: /a)
 /help — гэтая даведка
 
 Інлайн: напішы @rollrobot [натацыя] ў любым чаце або абяры варыянт са спіса.
@@ -36,6 +44,7 @@ export const be: Messages = {
     { command: 'roll', description: 'Кідок кубікаў — /roll 2d20kh1+5' },
     { command: 'full', description: 'Кідок з разборам — /full 4d6kh3' },
     { command: 'random', description: 'Кідок d100' },
+    { command: 'ask', description: 'Адказ Yes або No — /ask Атакуем?' },
     { command: 'help', description: 'Даведка па натацыі і спасылкі' },
   ],
 
@@ -52,5 +61,5 @@ export const be: Messages = {
 4dF для Fate
 d% для Call of Cthulhu
 
-/roll дае суму, /full — разбор па кубіках, /help — даведку па натацыі. Напішы @rollrobot у любым чаце, каб кінуць кубікі без дадавання бота.`,
+/roll дае суму, /full — разбор па кубіках, /ask — Yes або No, /help — даведку па натацыі. Напішы @rollrobot у любым чаце, каб кінуць кубікі без дадавання бота.`,
 };

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -2,7 +2,14 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const de: Messages = {
-  inline: { roll: 'Wurf', full: 'Aufschlüsselung', random: 'Zufallswurf', help: 'Anleitung' },
+  inline: {
+    roll: 'Wurf',
+    full: 'Aufschlüsselung',
+    random: 'Zufallswurf',
+    ask: 'Frage',
+    answer: 'Antwortet Yes oder No',
+    help: 'Anleitung',
+  },
 
   help: `Würfle wie noch nie — vollständige Rollenspiel-Notation mit Behalten/Verwerfen, explodierenden Würfeln, Wiederholungswürfen, Erfolgspools und Proben.
 
@@ -10,6 +17,7 @@ export const de: Messages = {
 /roll [Notation] — würfelt und zeigt die Summe (Kurzform: /r)
 /full [Notation] — würfelt mit Aufschlüsselung pro Würfel (Kurzform: /f)
 /random — würfelt d100 (<code>d%</code>)
+/ask [Frage] — antwortet Yes oder No (Kurzform: /a)
 /help — diese Anleitung
 
 Inline: tippe @rollrobot [Notation] in jedem Chat, oder wähle einen Eintrag aus der Liste.
@@ -36,6 +44,7 @@ Probiere die Notation im ${playground('Playground')} aus, oder lies die ${refere
     { command: 'roll', description: 'Würfeln — /roll 2d20kh1+5' },
     { command: 'full', description: 'Würfeln mit Aufschlüsselung — /full 4d6kh3' },
     { command: 'random', description: 'Würfeln — d100' },
+    { command: 'ask', description: 'Antwortet Yes oder No — /ask Angreifen?' },
     { command: 'help', description: 'Notationsanleitung und Links' },
   ],
 
@@ -52,5 +61,5 @@ Probiere die Notation im ${playground('Playground')} aus, oder lies die ${refere
 4dF für Fate
 d% für Call of Cthulhu
 
-/roll liefert die Summe, /full die Aufschlüsselung pro Würfel, /help die Notationsübersicht. Tippe @rollrobot in jedem Chat, um ohne Hinzufügen des Bots zu würfeln.`,
+/roll liefert die Summe, /full die Aufschlüsselung pro Würfel, /ask ein Yes oder No, /help die Notationsübersicht. Tippe @rollrobot in jedem Chat, um ohne Hinzufügen des Bots zu würfeln.`,
 };

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -2,7 +2,14 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const en: Messages = {
-  inline: { roll: 'Roll', full: 'Full', random: 'Random', help: 'How to use' },
+  inline: {
+    roll: 'Roll',
+    full: 'Full',
+    random: 'Random',
+    ask: 'Ask',
+    answer: 'Answers Yes or No',
+    help: 'How to use',
+  },
 
   help: `Roll the dice like no one before — full RPG notation with keep/drop, exploding dice, rerolls, success pools, and checks.
 
@@ -10,6 +17,7 @@ export const en: Messages = {
 /roll [notation] — roll and show the total (shortcut: /r)
 /full [notation] — roll with a die-by-die breakdown (shortcut: /f)
 /random — roll d100 (<code>d%</code>)
+/ask [question] — answer Yes or No (shortcut: /a)
 /help — this guide
 
 Inline: type @rollrobot [notation] in any chat, or pick a preset from the list.
@@ -36,6 +44,7 @@ Try notation live in the ${playground('playground')}, or read the full ${referen
     { command: 'roll', description: 'Roll dice — /roll 2d20kh1+5' },
     { command: 'full', description: 'Roll with a breakdown — /full 4d6kh3' },
     { command: 'random', description: 'Roll d100' },
+    { command: 'ask', description: 'Answer Yes or No — /ask Should we attack?' },
     { command: 'help', description: 'Notation guide and links' },
   ],
 
@@ -52,5 +61,5 @@ Try notation live in the ${playground('playground')}, or read the full ${referen
 4dF for Fate
 d% for Call of Cthulhu
 
-/roll gives the total, /full a die-by-die breakdown, /help the notation guide. Type @rollrobot in any chat to roll without adding the bot.`,
+/roll gives the total, /full a die-by-die breakdown, /ask a Yes or No, /help the notation guide. Type @rollrobot in any chat to roll without adding the bot.`,
 };

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -2,7 +2,14 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const es: Messages = {
-  inline: { roll: 'Tirada', full: 'Desglose', random: 'Aleatoria', help: 'Cómo se usa' },
+  inline: {
+    roll: 'Tirada',
+    full: 'Desglose',
+    random: 'Aleatoria',
+    ask: 'Pregunta',
+    answer: 'Responde Yes o No',
+    help: 'Cómo se usa',
+  },
 
   help: `Tira los dados como nadie — notación de rol completa con mantener/descartar, dados explosivos, nuevas tiradas, reservas de éxitos y pruebas.
 
@@ -10,6 +17,7 @@ export const es: Messages = {
 /roll [notación] — tira y muestra el total (atajo: /r)
 /full [notación] — tira con el desglose dado a dado (atajo: /f)
 /random — tira d100 (<code>d%</code>)
+/ask [pregunta] — responde Yes o No (atajo: /a)
 /help — esta guía
 
 En línea: escribe @rollrobot [notación] en cualquier chat, o elige una opción de la lista.
@@ -36,6 +44,7 @@ Comprueba la notación en vivo en el ${playground('área de pruebas')}, o consul
     { command: 'roll', description: 'Tira dados — /roll 2d20kh1+5' },
     { command: 'full', description: 'Tira con desglose — /full 4d6kh3' },
     { command: 'random', description: 'Tira d100' },
+    { command: 'ask', description: 'Responde Yes o No — /ask ¿Atacamos?' },
     { command: 'help', description: 'Guía de notación y enlaces' },
   ],
 
@@ -52,5 +61,5 @@ Comprueba la notación en vivo en el ${playground('área de pruebas')}, o consul
 4dF para Fate
 d% para Call of Cthulhu
 
-/roll da el total, /full el desglose dado a dado, /help la guía de notación. Escribe @rollrobot en cualquier chat para tirar sin añadir el bot.`,
+/roll da el total, /full el desglose dado a dado, /ask un Yes o No, /help la guía de notación. Escribe @rollrobot en cualquier chat para tirar sin añadir el bot.`,
 };

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -8,7 +8,14 @@ import type { Messages } from './types';
 //   splits `2d10-1` in two. All of it assumes the client resolves direction per line.
 
 export const fa: Messages = {
-  inline: { roll: 'پرتاب', full: 'جزئیات', random: 'پرتاب تصادفی', help: 'راهنما' },
+  inline: {
+    roll: 'پرتاب',
+    full: 'جزئیات',
+    random: 'پرتاب تصادفی',
+    ask: 'پرسش',
+    answer: 'پاسخ Yes یا No',
+    help: 'راهنما',
+  },
 
   help: `مثل هیچ‌کس دیگری تاس بینداز — نمادگذاری کامل بازی‌های نقش‌آفرینی: نگه‌داشتن و کنار گذاشتن، تاس انفجاری، پرتاب مجدد، شمارش موفقیت‌ها و چک در برابر درجهٔ سختی.
 
@@ -16,6 +23,7 @@ export const fa: Messages = {
 /roll 2d20+5 — پرتاب و نمایش مجموع، میان‌بر /r
 /full 4d6kh3 — پرتاب با جزئیات هر تاس، میان‌بر /f
 /random — پرتاب تاس d100 (<code>d%</code>)
+/ask — پاسخ Yes یا No، میان‌بر /a
 /help — همین راهنما
 
 Inline: @rollrobot را در هر گفت‌وگو همراه با نمادگذاری بنویس، یا از فهرست انتخاب کن
@@ -44,6 +52,7 @@ Inline: @rollrobot را در هر گفت‌وگو همراه با نمادگذا
     { command: 'roll', description: '/roll 2d20kh1+5 — پرتاب تاس' },
     { command: 'full', description: '/full 4d6kh3 — پرتاب با جزئیات' },
     { command: 'random', description: '/random — پرتاب تاس d100' },
+    { command: 'ask', description: '/ask — پاسخ Yes یا No' },
     { command: 'help', description: 'راهنمای نمادگذاری و پیوندها' },
   ],
 
@@ -62,6 +71,7 @@ d% برای Call of Cthulhu
 
 /roll — مجموع را می‌دهد
 /full — جزئیات هر تاس
+/ask — پاسخ Yes یا No
 /help — راهنمای نمادگذاری
 
 @rollrobot را در هر گفت‌وگو بنویس تا بدون افزودن ربات تاس بیندازی`,

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -2,7 +2,14 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const pt: Messages = {
-  inline: { roll: 'Rolagem', full: 'Detalhada', random: 'Aleatória', help: 'Como usar' },
+  inline: {
+    roll: 'Rolagem',
+    full: 'Detalhada',
+    random: 'Aleatória',
+    ask: 'Pergunta',
+    answer: 'Responde Yes ou No',
+    help: 'Como usar',
+  },
 
   help: `Role os dados como ninguém — notação de RPG completa com manter/descartar, dados explosivos, novas rolagens, reservas de sucessos e testes.
 
@@ -10,6 +17,7 @@ export const pt: Messages = {
 /roll [notação] — rola e mostra o total (atalho: /r)
 /full [notação] — rola com o detalhe dado a dado (atalho: /f)
 /random — rola d100 (<code>d%</code>)
+/ask [pergunta] — responde Yes ou No (atalho: /a)
 /help — este guia
 
 Inline: digite @rollrobot [notação] em qualquer conversa, ou escolha uma opção da lista.
@@ -36,6 +44,7 @@ Teste a notação no ${playground('playground')}, ou leia a ${reference('referê
     { command: 'roll', description: 'Role dados — /roll 2d20kh1+5' },
     { command: 'full', description: 'Role com detalhe — /full 4d6kh3' },
     { command: 'random', description: 'Role d100' },
+    { command: 'ask', description: 'Responde Yes ou No — /ask Vamos atacar?' },
     { command: 'help', description: 'Guia de notação e links' },
   ],
 
@@ -52,5 +61,5 @@ Teste a notação no ${playground('playground')}, ou leia a ${reference('referê
 4dF para Fate
 d% para Call of Cthulhu
 
-/roll dá o total, /full o detalhe dado a dado, /help o guia de notação. Digite @rollrobot em qualquer conversa para rolar sem adicionar o bot.`,
+/roll dá o total, /full o detalhe dado a dado, /ask um Yes ou No, /help o guia de notação. Digite @rollrobot em qualquer conversa para rolar sem adicionar o bot.`,
 };

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -2,7 +2,14 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const ru: Messages = {
-  inline: { roll: 'Бросок', full: 'Разбор', random: 'Наугад', help: 'Как пользоваться' },
+  inline: {
+    roll: 'Бросок',
+    full: 'Разбор',
+    random: 'Наугад',
+    ask: 'Вопрос',
+    answer: 'Отвечает Yes или No',
+    help: 'Как пользоваться',
+  },
 
   help: `Бросай кубики как никто другой — полная ролевая нотация: оставить/отбросить, взрывающиеся кубики, перебросы, пулы успехов и проверки.
 
@@ -10,6 +17,7 @@ export const ru: Messages = {
 /roll [нотация] — бросок с суммой (сокращение: /r)
 /full [нотация] — бросок с разбором по кубикам (сокращение: /f)
 /random — бросок d100 (<code>d%</code>)
+/ask [вопрос] — ответ Yes или No (сокращение: /a)
 /help — эта справка
 
 Инлайн: напиши @rollrobot [нотация] в любом чате или выбери вариант из списка.
@@ -36,6 +44,7 @@ export const ru: Messages = {
     { command: 'roll', description: 'Бросок кубиков — /roll 2d20kh1+5' },
     { command: 'full', description: 'Бросок с разбором — /full 4d6kh3' },
     { command: 'random', description: 'Бросок d100' },
+    { command: 'ask', description: 'Ответ Yes или No — /ask Атакуем?' },
     { command: 'help', description: 'Справка по нотации и ссылки' },
   ],
 
@@ -52,5 +61,5 @@ export const ru: Messages = {
 4dF для Fate
 d% для Call of Cthulhu
 
-/roll даёт сумму, /full — разбор по кубикам, /help — справку по нотации. Напиши @rollrobot в любом чате, чтобы бросить кубики без добавления бота.`,
+/roll даёт сумму, /full — разбор по кубикам, /ask — Yes или No, /help — справку по нотации. Напиши @rollrobot в любом чате, чтобы бросить кубики без добавления бота.`,
 };

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -4,8 +4,12 @@ export interface CommandText {
 }
 
 export interface Messages {
-  /** Inline result titles mirroring the commands they stand for, plus the help button above them. */
-  inline: { roll: string; full: string; random: string; help: string };
+  /**
+   * Inline result titles mirroring the commands they stand for, plus `answer` — the one
+   * description line the list carries, since an answer has no notation to echo — and the
+   * help button above them.
+   */
+  inline: { roll: string; full: string; random: string; ask: string; answer: string; help: string };
   help: string;
   commands: CommandText[];
   /** Profile blurb shown in search — Telegram caps it at 120 characters. */

--- a/src/locales/uk.ts
+++ b/src/locales/uk.ts
@@ -2,7 +2,14 @@ import { playground, reference } from './links';
 import type { Messages } from './types';
 
 export const uk: Messages = {
-  inline: { roll: 'Кидок', full: 'Докладно', random: 'Випадковий', help: 'Як користуватися' },
+  inline: {
+    roll: 'Кидок',
+    full: 'Докладно',
+    random: 'Випадковий',
+    ask: 'Питання',
+    answer: 'Відповідає Yes або No',
+    help: 'Як користуватися',
+  },
 
   help: `Кидай кубики як ніхто інший — повна рольова нотація: утримання/відкидання, вибухові кубики, перекидання, пул успіху і перевірки.
 
@@ -10,6 +17,7 @@ export const uk: Messages = {
 /roll [нотація] — кидок і сума (скорочення: /r)
 /full [нотація] — кидок з розбором по кубиках (скорочення: /f)
 /random — кидок d100 (<code>d%</code>)
+/ask [питання] — відповідь Yes або No (скорочення: /a)
 /help — ця довідка
 
 Інлайн: напиши @rollrobot [нотація] у будь-якому чаті або вибери варіант зі списку.
@@ -36,6 +44,7 @@ export const uk: Messages = {
     { command: 'roll', description: 'Кидок кубиків — /roll 2d20kh1+5' },
     { command: 'full', description: 'Кидок з розбором — /full 4d6kh3' },
     { command: 'random', description: 'Кидок d100' },
+    { command: 'ask', description: 'Відповідь Yes або No — /ask Атакуємо?' },
     { command: 'help', description: 'Довідка з нотації та посилання' },
   ],
 
@@ -52,5 +61,5 @@ export const uk: Messages = {
 4dF для Fate
 d% для Call of Cthulhu
 
-/roll дає суму, /full — розбір по кубиках, /help — довідку з нотації. Напиши @rollrobot у будь-якому чаті, щоб кинути кубики без додавання бота.`,
+/roll дає суму, /full — розбір по кубиках, /ask — Yes або No, /help — довідку з нотації. Напиши @rollrobot у будь-якому чаті, щоб кинути кубики без додавання бота.`,
 };

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -77,6 +77,19 @@ describe('Chosen inline results', () => {
     expect(await chosenLog('abc', 'd20')).toEqual('@testuser [inline] unknown d20');
   });
 
+  test('should log a chosen answer without re-resolving the query as notation', async () => {
+    expect(await chosenLog('ask:abc', 'will it rain')).toEqual(
+      '@testuser [inline] ask will it rain',
+    );
+    expect(await chosenLog('ask:abc', '2d6')).toEqual('@testuser [inline] ask 2d6');
+  });
+
+  test('should keep a chosen answer on one log line', async () => {
+    expect(await chosenLog('ask:abc', 'north\nor south')).toEqual(
+      '@testuser [inline] ask north or south',
+    );
+  });
+
   test('should log the label of a queried roll', async () => {
     expect(await chosenLog('roll:abc', '2d20+1 "Perception"')).toEqual(
       '@testuser [inline] roll 2d20+1 "Perception"',
@@ -122,6 +135,24 @@ describe('Command logging', () => {
   test('should log the normalized notation of shorthand and empty input', async () => {
     expect(await commandLog('/roll')).toMatch(/^@testuser \/roll d20 \| /);
     expect(await commandLog('/roll 2 10 -1')).toMatch(/^@testuser \/roll 2d10-1 \| /);
+  });
+
+  test('should log the question and the answer', async () => {
+    expect(await commandLog('/ask Should we attack?')).toMatch(
+      /^@testuser \/ask Should we attack\? \| Should we attack\? (Yes ✅|No ❌)$/,
+    );
+  });
+
+  test('should log an answer to no question without a gap', async () => {
+    expect(await commandLog('/ask')).toMatch(/^@testuser \/ask \| (Yes ✅|No ❌)$/);
+  });
+
+  // ! A newline reaching the log verbatim would forge a second entry that reads like a real one
+  test('should collapse a multi-line question onto one line', async () => {
+    expect(await commandLog('/ask north\nor south?')).toMatch(
+      /^@testuser \/ask north or south\? \| north or south\? (Yes ✅|No ❌)$/,
+    );
+    expect(await commandLog('/roll 2d6 "a\nb"')).toMatch(/^@testuser \/roll 2d6 "a b" \| /);
   });
 });
 
@@ -171,6 +202,22 @@ describe('Analytics tracking', () => {
 
     await tracked.sendChosenInline('random:abc');
     expect(dataset.points.at(-1)?.blobs?.[1]).toEqual('1d100');
+  });
+
+  test('should record /ask with no dice term, keeping the d2 out of dice rows', async () => {
+    await tracked.send('/ask Should we attack?');
+
+    expect(dataset.points).toHaveLength(1);
+    expect(dataset.points[0].indexes).toEqual(['ask']);
+    expect(dataset.points[0].blobs?.slice(0, 4)).toEqual(['ask', '', '', 'private']);
+  });
+
+  test('should record a chosen answer as ask rather than a phantom roll', async () => {
+    await tracked.sendChosenInline('ask:abc', 'will it rain');
+
+    expect(dataset.points).toHaveLength(1);
+    expect(dataset.points[0].indexes).toEqual(['ask']);
+    expect(dataset.points[0].blobs?.slice(0, 4)).toEqual(['ask', '', '', 'inline']);
   });
 
   test('should not record inline queries, which fire per keystroke', async () => {

--- a/test/handlers/ask.test.ts
+++ b/test/handlers/ask.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { TestBot } from '../helpers';
+import { askReply } from '../../src/handlers/ask';
+
+let bot: TestBot;
+
+beforeEach(() => {
+  bot = new TestBot();
+});
+
+const ANSWER = /^(<b>Yes<\/b> ✅|<b>No<\/b> ❌)$/;
+
+/** The reply split into its quote and its answer; the quote is absent when nothing was asked. */
+function parts(reply: string): { quote?: string; answer: string } {
+  const lines = reply.split('\n');
+  return lines.length === 1 ? { answer: lines[0] } : { quote: lines[0], answer: lines[1] };
+}
+
+describe('/ask', () => {
+  test('should answer Yes or No with no question', async () => {
+    expect(await bot.send('/ask')).toMatch(ANSWER);
+  });
+
+  test('should quote the question above the answer', async () => {
+    const { quote, answer } = parts(await bot.send('/ask Should we attack the dragon?'));
+    expect(quote).toEqual('<blockquote>Should we attack the dragon?</blockquote>');
+    expect(answer).toMatch(ANSWER);
+  });
+
+  test('should answer through the /a shortcut', async () => {
+    const { quote, answer } = parts(await bot.send('/a Do I trust him?'));
+    expect(quote).toEqual('<blockquote>Do I trust him?</blockquote>');
+    expect(answer).toMatch(ANSWER);
+  });
+
+  test('should give both answers over many asks', async () => {
+    const answers = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      answers.add(parts(await bot.send('/ask Heads?')).answer);
+    }
+    expect(answers.size).toEqual(2);
+  });
+
+  test('should escape HTML in the question', async () => {
+    const { quote } = parts(await bot.send('/ask <b>now</b> or never?'));
+    expect(quote).toEqual('<blockquote>&lt;b&gt;now&lt;/b&gt; or never?</blockquote>');
+  });
+
+  // Nothing else on this path caps the question — `extractLabel` never runs
+  test('should stay inside the Telegram message limit for a huge question', async () => {
+    const reply = await bot.send(`/ask ${'&'.repeat(4000)}`);
+    expect(reply.length).toBeLessThan(4096);
+    expect(parts(reply).quote).toEndWith('…</blockquote>');
+  });
+
+  test('should not truncate a question that fits', async () => {
+    const question = 'a'.repeat(300);
+    expect(parts(await bot.send(`/ask ${question}`)).quote).toEqual(
+      `<blockquote>${question}</blockquote>`,
+    );
+  });
+
+  // grammY trims only the leading side of a command argument
+  test('should trim trailing whitespace off the question', async () => {
+    expect(parts(await bot.send('/ask Rain?  \n\n')).quote).toEqual(
+      '<blockquote>Rain?</blockquote>',
+    );
+  });
+
+  test('should keep a multi-line question inside the quote', async () => {
+    expect(parts(await bot.send('/ask north\nor south?')).quote).toEqual('<blockquote>north');
+  });
+
+  test('should treat a whitespace-only question as none', async () => {
+    expect(await bot.send('/ask     ')).toMatch(ANSWER);
+  });
+
+  // The quoted-label syntax is a roll feature; here the whole argument is the question
+  test('should keep quotes as part of the question', async () => {
+    expect(parts(await bot.send('/ask 2d6 "Perception"?')).quote).toEqual(
+      '<blockquote>2d6 "Perception"?</blockquote>',
+    );
+  });
+
+  describe('askReply', () => {
+    test('should report the question it quoted', () => {
+      expect(askReply('  Rain?  ').question).toEqual('Rain?');
+      expect(askReply('').question).toBeNull();
+      expect(askReply(undefined).question).toBeNull();
+      expect(askReply(null).question).toBeNull();
+    });
+
+    test('should report the capped question, not the raw one', () => {
+      expect(askReply('x'.repeat(400)).question).toEqual(`${'x'.repeat(299)}…`);
+    });
+  });
+});

--- a/test/handlers/inline.test.ts
+++ b/test/handlers/inline.test.ts
@@ -16,6 +16,10 @@ const PRESET_ARTICLES = [
   { title: 'Random', description: 'd100' },
 ];
 
+const ASK_ARTICLE = { title: 'Ask', description: 'Answers Yes or No' };
+
+const ANSWER = /^(<b>Yes<\/b> ✅|<b>No<\/b> ❌)$/;
+
 function expectArticles(results: any[], expected: { title: string; description?: string }[]) {
   expect(results.length).toEqual(expected.length);
   for (let i = 0; i < expected.length; i++) {
@@ -46,9 +50,9 @@ describe('Inline queries', () => {
     expectArticles(results, PRESET_ARTICLES);
   });
 
-  test('should return preset articles for invalid query', async () => {
+  test('should lead with the ask article for a query that is not notation', async () => {
     const results = await bot.sendInline('abc');
-    expectArticles(results, PRESET_ARTICLES);
+    expectArticles(results, [ASK_ARTICLE, ...PRESET_ARTICLES]);
   });
 
   test('should prefix preset article ids with their variant', async () => {
@@ -137,6 +141,7 @@ describe('Inline queries', () => {
     expectArticles(results, [
       { title: 'Roll', description: '2d10 - 1' },
       { title: 'Full', description: '2d10 - 1' },
+      ASK_ARTICLE,
     ]);
   });
 
@@ -199,9 +204,11 @@ describe('Inline queries', () => {
       }
     });
 
+    // A quoted string on its own is a question as readily as it is a roll name, so it gets both
     test('should roll the default when only a label is given', async () => {
       const results = await bot.sendInline('"attack"');
       expectArticles(results, [
+        ASK_ARTICLE,
         { title: 'Roll', description: '1d20' },
         { title: 'Full', description: '1d20' },
       ]);
@@ -210,15 +217,16 @@ describe('Inline queries', () => {
 
     test('should fall back to presets with help button for an unterminated quote', async () => {
       const results = await bot.sendInline('4d6 "chars');
-      expectArticles(results, PRESET_ARTICLES);
+      expectArticles(results, [ASK_ARTICLE, ...PRESET_ARTICLES]);
       expect(bot.inlineResults[0].button).toEqual(HELP_BUTTON);
     });
 
     test('should fall back to presets when the notation is invalid', async () => {
       const results = await bot.sendInline('xyz "label"');
-      expectArticles(results, PRESET_ARTICLES);
+      expectArticles(results, [ASK_ARTICLE, ...PRESET_ARTICLES]);
       expect(bot.inlineResults[0].button).toEqual(HELP_BUTTON);
-      for (const result of results) {
+      // The presets carry no label; only the ask article quotes anything
+      for (const result of results.slice(1)) {
         expect(result.input_message_content.message_text).not.toContain('<blockquote>');
       }
     });
@@ -233,7 +241,88 @@ describe('Inline queries', () => {
 
   test('should fall back to presets with help button above the dice limit', async () => {
     const results = await bot.sendInline('999d6');
-    expectArticles(results, PRESET_ARTICLES);
+    expectArticles(results, [ASK_ARTICLE, ...PRESET_ARTICLES]);
     expect(bot.inlineResults[0].button).toEqual(HELP_BUTTON);
+  });
+
+  describe('Ask article', () => {
+    function titles(results: any[]): string[] {
+      return results.map((result) => result.title);
+    }
+
+    function askText(results: any[]): string {
+      return results.find((result) => result.title === ASK_ARTICLE.title).input_message_content
+        .message_text;
+    }
+
+    // Nothing typed yet, and a lone `d` is notation on its way in
+    test('should be absent until something is asked', async () => {
+      for (const query of ['', '   ', 'd']) {
+        expect(titles(await bot.sendInline(query))).not.toContain(ASK_ARTICLE.title);
+      }
+    });
+
+    test('should be absent for notation that names a die', async () => {
+      for (const query of ['d20', '2d20+5', '4dF', 'd%', '4d6kh3', '2d6 "Attack"']) {
+        expect(titles(await bot.sendInline(query))).not.toContain(ASK_ARTICLE.title);
+      }
+    });
+
+    // `2024` rolls a d2024 and `1 2` a 1d2, but neither is a die anyone named
+    test('should trail the roll for bare-number shorthand', async () => {
+      for (const query of ['2024', '1 2', '2 10 -1']) {
+        expect(titles(await bot.sendInline(query))).toEqual(['Roll', 'Full', ASK_ARTICLE.title]);
+      }
+    });
+
+    test('should lead for text that is not notation', async () => {
+      for (const query of ['will it rain tomorrow', '去', '?', 'should I text her']) {
+        expect(titles(await bot.sendInline(query))[0]).toEqual(ASK_ARTICLE.title);
+      }
+    });
+
+    // A `d` inside a word must not read as a die: "Should" carries one
+    test('should lead for a quoted question, which parses as a labelled d20', async () => {
+      for (const query of ['"Should I text her?"', '«Стоит ли?»', '“Should we?”']) {
+        const results = await bot.sendInline(query);
+        expect(titles(results)).toEqual([ASK_ARTICLE.title, 'Roll', 'Full']);
+      }
+    });
+
+    test('should quote the question above a Yes or No', async () => {
+      const results = await bot.sendInline('will it rain');
+      const [quote, answer] = askText(results).split('\n');
+      expect(quote).toEqual('<blockquote>will it rain</blockquote>');
+      expect(answer).toMatch(ANSWER);
+    });
+
+    test('should answer both ways across many queries', async () => {
+      const answers = new Set<string>();
+      for (let i = 0; i < 200; i++) {
+        answers.add(askText(await bot.sendInline('coin')).split('\n')[1]);
+      }
+      expect(answers.size).toEqual(2);
+    });
+
+    test('should escape HTML in the question', async () => {
+      const results = await bot.sendInline('<b>now</b>?');
+      expect(askText(results)).toStartWith('<blockquote>&lt;b&gt;now&lt;/b&gt;?</blockquote>\n');
+    });
+
+    test('should prefix its id with the ask variant', async () => {
+      const results = await bot.sendInline('will it rain');
+      expect(results[0].id.split(':')[0]).toEqual('ask');
+    });
+
+    test('should localize its title and description', async () => {
+      const ru = messages('ru').inline;
+      const results = await bot.sendInline('буде дождь', 'ru');
+      expect(results[0]).toMatchObject({ title: ru.ask, description: ru.answer });
+    });
+
+    test('should leave the help button in place', async () => {
+      await bot.sendInline('will it rain');
+      expect(bot.inlineResults[0].button).toEqual(HELP_BUTTON);
+    });
   });
 });

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -67,7 +67,13 @@ describe('messages', () => {
       });
 
       test('lists the same commands as English', () => {
-        expect(entry.commands.map((c) => c.command)).toEqual(['roll', 'full', 'random', 'help']);
+        expect(entry.commands.map((c) => c.command)).toEqual([
+          'roll',
+          'full',
+          'random',
+          'ask',
+          'help',
+        ]);
         for (const { description } of entry.commands) {
           expect(description.length).toBeGreaterThan(0);
           expect(description.length).toBeLessThanOrEqual(256);
@@ -106,7 +112,7 @@ describe('messages', () => {
       });
 
       test('advertises only the current commands', () => {
-        for (const command of ['/roll', '/full', '/random', '/help']) {
+        for (const command of ['/roll', '/full', '/random', '/ask', '/help']) {
           expect(entry.help).toContain(command);
         }
         for (const retired of ['/sroll', '/droll', '/wod']) {
@@ -123,7 +129,7 @@ describe('fa', () => {
 
   // `@` strands at the far end of a mention the same way `/` does on a command, so a line
   // carrying either needs the Latin anchor
-  const NOTATION_LINE = /\/(roll|full|random|help|r|f)\b|\d*d[\d%F]|@\w/;
+  const NOTATION_LINE = /\/(roll|full|random|ask|help|r|f|a)\b|\d*d[\d%F]|@\w/;
 
   test('uses Persian letter forms rather than Arabic ones', () => {
     for (const text of allText(entry)) {


### PR DESCRIPTION
Adds `/ask` (shortcut `/a`): the whole argument is the question, quoted above a random `Yes ✅` or `No ❌`. The answer stays English in every locale, since the sender's interface language is a poor guess at the language of the chat.

- `askReply` in `src/handlers/ask.ts`, answering off a `d2`
- An inline `Ask` article, hidden only when the notation parses **and** names a die explicitly — so `2024` and `1 2` still offer it, and `Should I text her?` is not caught by the `d` in "Should"
- `Ask` leads the list when the query did not roll on notation of its own, trails it when it did
- `hasInvalidQuery` left on the parse alone, so a question still raises the **How to use** button
- Question capped at 300 code points; nothing on this path reached `extractLabel`'s own cap, so a long question could exceed Telegram's 4096 limit once escaped and fail to send at all
- Newlines collapsed in the logged request, which could otherwise forge a second log line — already reachable through a roll's label
- `ask` recorded via `trackCommand`, keeping the `d2` out of dice-shape rows
- Documented in all eight locales, the README and `ANALYTICS.md`; `shortDescription` left alone, as `uk` sits at 109 of Telegram's 120 cap

Closes #65
