### PR TITLE
improvement: forgiving input normalization #71

### DIFF
--- a/src/label.ts
+++ b/src/label.ts
@@ -1,3 +1,6 @@
+import { isNotationError, parse } from 'roll-parser';
+import { normalizeNotation } from './notation';
+
 /**
  * Closing quote to the openers it accepts. No quote character is a roll-parser
  * token, so a quoted tail can be stripped without consulting the parser.
@@ -46,30 +49,86 @@ export interface LabelledInput {
   label: string | null;
 }
 
+/** Every character some pair accepts as an opener. */
+const OPENING_QUOTES = new Set([...Object.values(QUOTE_PAIRS).join('')]);
+
 /**
- * Splits a trailing quoted label off the input: `2d20+1 "Perception"` becomes
- * notation `2d20+1` and label `Perception`. The opener is the *first* accepted
- * quote in the string rather than the nearest one — a quote can never be part of
- * valid notation, so everything from it onward belongs to the label, and nested
- * quotes (`2d6 "he said "hi""`) survive intact.
+ * Whether the notation half of a candidate split is something the parser accepts.
  *
- * An unterminated quote is left in the notation for the parser to reject.
+ * `parse` rather than `roll`: no RNG and no `ROLL_LIMITS`, so a rejected candidate
+ * costs a lex and a parse — cheap enough to run several times per inline keystroke.
  */
-export function extractLabel(input: string): LabelledInput {
-  const trimmed = input.trim();
+function isParseable(notation: string): boolean {
+  try {
+    parse(normalizeNotation(notation));
+    return true;
+  } catch (error) {
+    if (isNotationError(error)) return false;
+    throw error;
+  }
+}
 
-  const openers = QUOTE_PAIRS[trimmed.at(-1) ?? ''];
-  if (openers == null) return { notation: trimmed, label: null };
-
-  const found = [...openers].map((char) => trimmed.indexOf(char)).filter((index) => index !== -1);
-  if (found.length === 0) return { notation: trimmed, label: null };
-
-  const open = Math.min(...found);
-  if (open === trimmed.length - 1) return { notation: trimmed, label: null };
-
-  const label = trimmed.slice(open + 1, -1).trim();
+function split(trimmed: string, open: number, end: number): LabelledInput {
+  const label = trimmed.slice(open + 1, end).trim();
   return {
     notation: trimmed.slice(0, open).trim(),
     label: label === '' ? null : capLabel(label),
   };
+}
+
+/**
+ * First quote that reads as an opener: at the start of the input, or after a space.
+ * Requiring the space is what keeps a mid-word apostrophe from opening a label —
+ * without a closer to prove intent, `2d6 s'more` would otherwise roll `2d6 s` sorted.
+ */
+function unterminatedOpener(trimmed: string): number {
+  for (let i = 0; i < trimmed.length; i++) {
+    if (!OPENING_QUOTES.has(trimmed.charAt(i))) continue;
+    if (i === 0 || /\s/.test(trimmed.charAt(i - 1))) return i;
+  }
+  return -1;
+}
+
+/**
+ * The splits worth trying, in the order a roll prefers them: a quote pair closed at
+ * the end of the input, then an unterminated opener.
+ *
+ * ? Only the *first* opener of each kind earns a candidate. A later one leaves the
+ * earlier quote inside the notation half, and no quote is a lexer token, so such a
+ * split can never parse.
+ */
+function* candidates(trimmed: string): Generator<LabelledInput> {
+  const openers = QUOTE_PAIRS[trimmed.at(-1) ?? ''];
+  const closed = [...(openers ?? '')]
+    .map((char) => trimmed.indexOf(char))
+    .filter((index) => index !== -1);
+
+  if (closed.length > 0) {
+    const open = Math.min(...closed);
+    // A closer that is its own opener can be the only quote in the input
+    if (open < trimmed.length - 1) yield split(trimmed, open, -1);
+  }
+
+  const open = unterminatedOpener(trimmed);
+  if (open !== -1) yield split(trimmed, open, trimmed.length);
+}
+
+/**
+ * Splits a trailing quoted label off the input: `2d20+1 "Perception"` becomes
+ * notation `2d20+1` and label `Perception`. A quote can never be part of valid
+ * notation, so everything from the opener onward belongs to the label, and nested
+ * quotes (`2d6 "he said "hi""`) survive intact.
+ *
+ * Which quote opens the label is a guess, so it is checked rather than trusted: the
+ * first candidate split whose notation parses wins, and an input where none parse is
+ * left whole for the parser to report on. A successful roll always beats a split.
+ */
+export function extractLabel(input: string): LabelledInput {
+  const trimmed = input.trim();
+
+  for (const candidate of candidates(trimmed)) {
+    if (isParseable(candidate.notation)) return candidate;
+  }
+
+  return { notation: trimmed, label: null };
 }

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -24,15 +24,49 @@ function foldNumerals(input: string): string {
 }
 
 /**
+ * Characters the parser rejects, mapped to the operator they were meant to be.
+ *
+ * The dash family is the one that matters: iOS and macOS rewrite `-` into `–` or `—`
+ * without telling anyone, so `2d6 – 1` is an error the user cannot see the cause of.
+ * `÷` and `×` are deliberate, but they sit on the same symbol page a phone offers
+ * instead of `/` and `*`.
+ *
+ * ? Kept to what a keyboard or an autocorrect actually produces. Typographic curios
+ * — `∗`, `·`, `‒`, the fullwidth forms — are errors nobody has hit.
+ */
+const CHARACTER_FOLDS: Record<string, string | undefined> = {
+  '÷': '/',
+  '×': '*',
+  '−': '-',
+  '–': '-',
+  '—': '-',
+};
+
+// Built from the keys so the two cannot drift apart. Safe as a character class only
+// because no key is a `-`, `]` or `^`
+const FOLDED = new RegExp(`[${Object.keys(CHARACTER_FOLDS).join('')}]`, 'g');
+
+/**
+ * Folds operator lookalikes to the ASCII the grammar accepts.
+ *
+ * ! Notation only, same as `foldNumerals` — `extractLabel` runs first at every call
+ * site, and a label is prose where a `–` is a `–`.
+ */
+function foldCharacters(input: string): string {
+  return input.replace(FOLDED, (char) => CHARACTER_FOLDS[char] ?? char);
+}
+
+/**
  * Rewrites pre-v3 shorthand into dice notation: a bare number rolls a die
  * with that many sides (`20` → `d20`), and the space-separated simplified
  * form becomes classic notation (`2 10 -1` → `2d10-1`). Anything else is
  * passed through for the parser to judge. Empty input defaults to `d20`.
  *
- * Eastern numerals are folded first, so the shorthand rules see `۲۰` as `20`.
+ * Characters are folded first, so the shorthand rules see `۲۰` as `20` and `۲ ۱۰ −۱`
+ * as a signed modifier.
  */
 export function normalizeNotation(input: string): string {
-  const trimmed = foldNumerals(input.trim());
+  const trimmed = foldCharacters(foldNumerals(input)).trim();
   if (trimmed === '') return 'd20';
 
   if (BARE_NUMBER.test(trimmed)) return `d${trimmed}`;

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -33,6 +33,11 @@ function foldNumerals(input: string): string {
  *
  * ? Kept to what a keyboard or an autocorrect actually produces. Typographic curios
  * — `∗`, `·`, `‒`, the fullwidth forms — are errors nobody has hit.
+ *
+ * `к` (from «кубик») and its transliterated cousin `д` are how the Cyrillic locales
+ * write a die — `2к6`, `к20`. Digits are shared across layouts, so the letter arrives
+ * from the wrong alphabet unnoticed. Cyrillic `к` (U+043A) is not Latin `k` (U+006B),
+ * so the `k` / `kh` / `kl` keep-modifiers are untouched.
  */
 const CHARACTER_FOLDS: Record<string, string | undefined> = {
   '÷': '/',
@@ -40,6 +45,10 @@ const CHARACTER_FOLDS: Record<string, string | undefined> = {
   '−': '-',
   '–': '-',
   '—': '-',
+  к: 'd',
+  К: 'd',
+  д: 'd',
+  Д: 'd',
 };
 
 // Built from the keys so the two cannot drift apart. Safe as a character class only

--- a/test/handlers/inline.test.ts
+++ b/test/handlers/inline.test.ts
@@ -215,8 +215,23 @@ describe('Inline queries', () => {
       expect(bot.inlineResults[0].button).toBeUndefined();
     });
 
-    test('should fall back to presets with help button for an unterminated quote', async () => {
+    test('should name the roll from an unterminated quote', async () => {
       const results = await bot.sendInline('4d6 "chars');
+      expectArticles(results, [
+        { title: 'Roll', description: '4d6' },
+        { title: 'Full', description: '4d6' },
+      ]);
+      for (const result of results) {
+        expect(result.input_message_content.message_text).toStartWith(
+          '<blockquote>chars</blockquote>\n',
+        );
+      }
+      expect(bot.inlineResults[0].button).toBeUndefined();
+    });
+
+    // No closer, so the apostrophe is not read as an opener — `2d6 don` would not parse
+    test('should fall back to presets for an unquoted apostrophe', async () => {
+      const results = await bot.sendInline("2d6 don't");
       expectArticles(results, [ASK_ARTICLE, ...PRESET_ARTICLES]);
       expect(bot.inlineResults[0].button).toEqual(HELP_BUTTON);
     });

--- a/test/handlers/roll.test.ts
+++ b/test/handlers/roll.test.ts
@@ -89,8 +89,14 @@ describe('/roll', () => {
       expect(reply).toContain('<pre>xyz');
     });
 
-    test('should leave an unterminated quote to the parser', async () => {
+    test('should name the roll from an unterminated quote', async () => {
       const reply = await bot.send('/roll 4d6 "chars');
+      expect(reply).toContain('<blockquote>chars</blockquote>');
+      expect(reply).toContain('<code>4d6</code>');
+    });
+
+    test('should leave an unquoted apostrophe to the parser', async () => {
+      const reply = await bot.send("/roll 2d6 don't");
       expect(reply).not.toContain('<blockquote>');
       expect(reply).toMatch(/^<i>.+<\/i>/);
     });

--- a/test/handlers/roll.test.ts
+++ b/test/handlers/roll.test.ts
@@ -108,5 +108,12 @@ describe('/roll', () => {
       expect(reply).toContain('<blockquote>ضربهٔ ۳</blockquote>');
       expect(reply).toContain('<code>2d6</code>');
     });
+
+    // ! Same order, one alphabet further: folding first would turn «проверка» into `провер d а`
+    test('should fold cyrillic dice specifiers but not the label', async () => {
+      const reply = await bot.send('/roll 1к20 «проверка»');
+      expect(reply).toContain('<blockquote>проверка</blockquote>');
+      expect(reply).toContain('<code>1d20</code>');
+    });
   });
 });

--- a/test/label.test.ts
+++ b/test/label.test.ts
@@ -44,10 +44,36 @@ describe('extractLabel', () => {
     expect(extractLabel('')).toEqual({ notation: '', label: null });
   });
 
-  test('leaves an unterminated quote in the notation', () => {
-    expect(extractLabel('4d6 "chars')).toEqual({ notation: '4d6 "chars', label: null });
-    expect(extractLabel('4d6 "')).toEqual({ notation: '4d6 "', label: null });
-    expect(extractLabel('"')).toEqual({ notation: '"', label: null });
+  test('accepts an unterminated opening quote', () => {
+    expect(extractLabel('4d6 "chars')).toEqual({ notation: '4d6', label: 'chars' });
+    expect(extractLabel('d2 “Customers wear Chockers')).toEqual({
+      notation: 'd2',
+      label: 'Customers wear Chockers',
+    });
+    expect(extractLabel('2d6 «атака')).toEqual({ notation: '2d6', label: 'атака' });
+  });
+
+  test('drops a quote left with nothing to open', () => {
+    expect(extractLabel('4d6 "')).toEqual({ notation: '4d6', label: null });
+    expect(extractLabel('"')).toEqual({ notation: '', label: null });
+  });
+
+  // Without a closer, only a quote after a space reads as an opener — otherwise
+  // `2d6 s'more` would split into the sort modifier `2d6 s` labelled `more`
+  test('leaves a mid-word apostrophe in the notation', () => {
+    expect(extractLabel("2d6 s'more")).toEqual({ notation: "2d6 s'more", label: null });
+    expect(extractLabel("2d6 don't")).toEqual({ notation: "2d6 don't", label: null });
+  });
+
+  // The mis-split `d20 it` / `s a trap` used to reach the parser and error there
+  test('leaves input whole when no split parses', () => {
+    expect(extractLabel("d20 it's a trap'")).toEqual({ notation: "d20 it's a trap'", label: null });
+  });
+
+  // Two keyboards, two quote families — the closer does not accept this opener,
+  // so the split only happens because the unterminated candidate is tried next
+  test('splits a mismatched quote pair', () => {
+    expect(extractLabel('2d6 ‘attack”')).toEqual({ notation: '2d6', label: 'attack”' });
   });
 
   test('reports a label with no notation', () => {

--- a/test/notation.test.ts
+++ b/test/notation.test.ts
@@ -55,6 +55,22 @@ describe('normalizeNotation', () => {
     expect(normalizeNotation('2d6×2')).toBe('2d6*2');
   });
 
+  // «кубик» — how the Cyrillic locales write a die, typed without noticing the letter
+  // came from the other layout
+  test('folds cyrillic dice specifiers to d', () => {
+    expect(normalizeNotation('2к6')).toBe('2d6');
+    expect(normalizeNotation('к20')).toBe('d20');
+    expect(normalizeNotation('2К6')).toBe('2d6');
+    expect(normalizeNotation('2д6')).toBe('2d6');
+    expect(normalizeNotation('2Д6+1')).toBe('2d6+1');
+  });
+
+  // Cyrillic `к` is U+043A, Latin `k` is U+006B — the keep modifiers are a different letter
+  test('leaves the latin keep modifiers alone', () => {
+    expect(normalizeNotation('4к6kh3')).toBe('4d6kh3');
+    expect(normalizeNotation('2к20kl1')).toBe('2d20kl1');
+  });
+
   test('passes dice notation through untouched', () => {
     expect(normalizeNotation('d20')).toBe('d20');
     expect(normalizeNotation('4d6kh3')).toBe('4d6kh3');

--- a/test/notation.test.ts
+++ b/test/notation.test.ts
@@ -40,6 +40,21 @@ describe('normalizeNotation', () => {
     expect(normalizeNotation('d٪')).toBe('d%');
   });
 
+  // iOS and macOS substitute these for `-` on their own, so the user never sees why
+  // `2d6 – 1` failed
+  test('folds the dash family to a minus', () => {
+    expect(normalizeNotation('2d6 − 1')).toBe('2d6 - 1');
+    expect(normalizeNotation('2d6 – 1')).toBe('2d6 - 1');
+    expect(normalizeNotation('2d6 — 1')).toBe('2d6 - 1');
+    expect(normalizeNotation('2 10 −1')).toBe('2d10-1');
+  });
+
+  // The symbol page a phone offers instead of `/` and `*`
+  test('folds math symbols to their operators', () => {
+    expect(normalizeNotation('2d6÷2')).toBe('2d6/2');
+    expect(normalizeNotation('2d6×2')).toBe('2d6*2');
+  });
+
   test('passes dice notation through untouched', () => {
     expect(normalizeNotation('d20')).toBe('d20');
     expect(normalizeNotation('4d6kh3')).toBe('4d6kh3');


### PR DESCRIPTION
Stages 1 and 2 of the epic. Stage 3 (#70) is not included.

## Changes

- `extractLabel` is candidate-driven: a split is returned only if its notation half survives `normalizeNotation` + `parse`, otherwise the next candidate is tried and finally no split at all
- An unterminated opening quote now opens a label — `4d6 "chars` rolls `4d6` named `chars`
- A mid-word apostrophe stays in the notation, so `2d6 s'more` cannot split into the sort modifier `2d6 s`
- `normalizeNotation` folds a character table to ASCII operators: the dash family to `-`, `÷` to `/`, `×` to `*`
- Cyrillic `к` `К` `д` `Д` fold to `d` on the same table; Latin `k` is a different code point, so `kh` / `kl` are untouched
- Folding stays behind label extraction, pinned by tests through the command path for both Persian numerals and a Cyrillic label

The fold table is limited to what a keyboard or an autocorrect actually produces. `∗`, `·` and `‒` are dropped — no mainstream layout emits them, and `·` is a Catalan letter component. The fullwidth block is dropped too: it is a regex over every notation for an audience with no bundled locale (`be de en es fa pt ru uk`). NFKC was rejected on the way, since it rewrites `d6²` to `d62` — a roll that succeeds and is not the one asked for.

`2d6 don't` still errors — unquoted trailing labels are #70.

Closes #67 #68 #69
