### PR TITLE
fix: fold Cyrillic к/д only in die position #89

### DIFF
--- a/src/notation.ts
+++ b/src/notation.ts
@@ -33,11 +33,6 @@ function foldNumerals(input: string): string {
  *
  * ? Kept to what a keyboard or an autocorrect actually produces. Typographic curios
  * — `∗`, `·`, `‒`, the fullwidth forms — are errors nobody has hit.
- *
- * `к` (from «кубик») and its transliterated cousin `д` are how the Cyrillic locales
- * write a die — `2к6`, `к20`. Digits are shared across layouts, so the letter arrives
- * from the wrong alphabet unnoticed. Cyrillic `к` (U+043A) is not Latin `k` (U+006B),
- * so the `k` / `kh` / `kl` keep-modifiers are untouched.
  */
 const CHARACTER_FOLDS: Record<string, string | undefined> = {
   '÷': '/',
@@ -45,10 +40,6 @@ const CHARACTER_FOLDS: Record<string, string | undefined> = {
   '−': '-',
   '–': '-',
   '—': '-',
-  к: 'd',
-  К: 'd',
-  д: 'd',
-  Д: 'd',
 };
 
 // Built from the keys so the two cannot drift apart. Safe as a character class only
@@ -56,13 +47,28 @@ const CHARACTER_FOLDS: Record<string, string | undefined> = {
 const FOLDED = new RegExp(`[${Object.keys(CHARACTER_FOLDS).join('')}]`, 'g');
 
 /**
- * Folds operator lookalikes to the ASCII the grammar accepts.
+ * `к` (from «кубик») and its transliterated cousin `д` are how the Cyrillic locales write
+ * a die — `2к6`, `к20`. Digits are shared across layouts, so the letter arrives from the
+ * wrong alphabet unnoticed.
+ *
+ * ! Matched in a die position only — no letter before, a digit after. Folding every
+ * occurrence rewrote the prose of a forgotten label into gibberish, and `formatError`
+ * echoed that back: `1d20 Бросок кубика` answered as `1d20 Бросоd dубиdа`.
+ *
+ * Cyrillic `к` (U+043A) is not Latin `k` (U+006B), so the `k` / `kh` / `kl` keep-modifiers
+ * are untouched. A Cyrillic one (`4d6кh3`) now fails to parse rather than folding into the
+ * `dh` drop-modifier, which rolled something other than what was asked for.
+ */
+const CYRILLIC_DIE = /(?<!\p{L})[кКдД](?=\d)/gu;
+
+/**
+ * Folds operator lookalikes and the Cyrillic die letter to the ASCII the grammar accepts.
  *
  * ! Notation only, same as `foldNumerals` — `extractLabel` runs first at every call
  * site, and a label is prose where a `–` is a `–`.
  */
 function foldCharacters(input: string): string {
-  return input.replace(FOLDED, (char) => CHARACTER_FOLDS[char] ?? char);
+  return input.replace(FOLDED, (char) => CHARACTER_FOLDS[char] ?? char).replace(CYRILLIC_DIE, 'd');
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -100,9 +100,9 @@ function clean(parts: string[], bullets: boolean): string[] {
  * `tier` reports which separator won, and is `null` when fewer than two options came
  * out — a lone option was never really split, whatever characters it contains.
  *
- * ! Never run `normalizeNotation` over any of this. It folds Cyrillic `к`/`д` to `d` for
- *   the roll path, which would turn `/pick кубик, карта` into `dубик`, and it rewrites a
- *   bare `5 10` into `5d10`. Options are prose, not notation.
+ * ! Never run `normalizeNotation` over any of this. It folds a Cyrillic `к`/`д` before a
+ *   digit to `d` for the roll path, which would turn `/pick к20, к6` into `d20, d6`, and
+ *   it rewrites a bare `5 10` into `5d10`. Options are prose, not notation.
  */
 export function splitOptions(input: string): SplitOptions {
   const { head, label, wrapped } = extractQuotedTail(input.trim());

--- a/test/handlers/roll.test.ts
+++ b/test/handlers/roll.test.ts
@@ -14,6 +14,14 @@ describe('/roll', () => {
     expect(await bot.send('/roll 4d6d1')).toMatch(/<pre>4d6d1\n {3}\^/);
   });
 
+  // ! The echo is the user's own text — folding `к`/`д` mid-word answered a forgotten quote
+  //   with `1d20 Бросоd dубиdа`, which reads as a bug in the bot rather than a hint
+  test('should echo an unescaped label as it was typed', async () => {
+    const reply = await bot.send('/roll 1d20 Бросок кубика');
+    expect(reply).toContain('<pre>1d20 Бросок кубика\n');
+    expect(reply).not.toContain('dубиdа');
+  });
+
   test('should parse and roll notation', async () => {
     const pattern = /^<code>[^<]+<\/code> = <b>-?\d+<\/b>$/;
     expect(await bot.send('/roll')).toMatch(pattern);

--- a/test/notation.test.ts
+++ b/test/notation.test.ts
@@ -65,6 +65,16 @@ describe('normalizeNotation', () => {
     expect(normalizeNotation('2Д6+1')).toBe('2d6+1');
   });
 
+  // ! The fold is what the error echo shows back, so folding mid-word answered a forgotten
+  //   quote with gibberish — `1d20 Бросок кубика` echoed as `1d20 Бросоd dубиdа`
+  test('folds cyrillic only in a die position', () => {
+    expect(normalizeNotation('1d20 Бросок кубика')).toBe('1d20 Бросок кубика');
+    expect(normalizeNotation('2d6 + кот')).toBe('2d6 + кот');
+    expect(normalizeNotation('2к6 Урон')).toBe('2d6 Урон');
+    // A word ending on `к` before a number is prose, not a die
+    expect(normalizeNotation('бросок20')).toBe('бросок20');
+  });
+
   // Cyrillic `к` is U+043A, Latin `k` is U+006B — the keep modifiers are a different letter
   test('leaves the latin keep modifiers alone', () => {
     expect(normalizeNotation('4к6kh3')).toBe('4d6kh3');


### PR DESCRIPTION
`normalizeNotation` folded every Cyrillic `к`/`д` in the input, prose included, so an unescaped label came back mangled — `/roll 1d20 Бросок кубика` answered `1d20 Бросоd dубиdа`. The fold now matches a die position only: no letter before, a digit after.

`formatError` is unchanged. The folds are 1:1 by code point so caret offsets still line up, and nothing folds to an invalid lexer token, so the parser message can never quote a character the user did not type.

A Cyrillic keep-modifier (`4d6кh3`) now fails to parse instead of folding into `4d6dh3` and silently rolling drop-highest.

Closes #89
